### PR TITLE
feat(controller): add CStorClusterConfigPlan resource

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,11 +20,11 @@ import (
 	"openebs.io/metac/controller/generic"
 	"openebs.io/metac/start"
 
-	ccdefault "cstorpoolauto/controller/clusterconfig/default"
+	ccreconciler "cstorpoolauto/controller/clusterconfig/reconciler"
 )
 
 func main() {
-	generic.AddToInlineRegistry("sync/cstorclusterconfig/default", ccdefault.Sync)
+	generic.AddToInlineRegistry("sync/cstorclusterconfig/default", ccreconciler.Sync)
 
 	start.Start()
 }

--- a/types/conditions.go
+++ b/types/conditions.go
@@ -27,10 +27,10 @@ import (
 type CStorClusterConfigConditionType string
 
 const (
-	// CStorClusterConfigConditionErrorSettingDefaults is used to
-	// indicate presence or absence of error while setting
-	// defaults against CStorClusterConfig
-	CStorClusterConfigConditionErrorSettingDefaults CStorClusterConfigConditionType = "ErrorSettingDefaults"
+	// CStorClusterConfigConditionReconcileError is used to
+	// indicate presence or absence of error while reconciling
+	// CStorClusterConfig
+	CStorClusterConfigConditionReconcileError CStorClusterConfigConditionType = "ReconcileError"
 )
 
 // CStorClusterConfigConditionStatus is a custom datatype that
@@ -47,45 +47,42 @@ const (
 	CStorClusterConfigConditionIsAbsent CStorClusterConfigConditionStatus = "False"
 )
 
-// MakeErrorSettingDefaultsCondition builds a new
-// CStorClusterConfigConditionErrorSettingDefault condition
+// MakeReconcileErrorCondition builds a new
+// CStorClusterConfigConditionReconcileError condition
 // suitable to be used in API status.conditions
-//
-// NOTE:
-// 	SetDefaultError points to cases when there is some error
-// while setting defaults against CStorClusterConfig
-func MakeErrorSettingDefaultsCondition(err error) map[string]string {
+func MakeReconcileErrorCondition(err error) map[string]string {
 	return map[string]string{
-		"type":             string(CStorClusterConfigConditionErrorSettingDefaults),
+		"type":             string(CStorClusterConfigConditionReconcileError),
 		"status":           string(CStorClusterConfigConditionIsPresent),
 		"reason":           err.Error(),
 		"lastObservedTime": time.Now().String(),
 	}
 }
 
-// MakeNoErrorSettingDefaultsCondition builds a new no
-// CStorClusterConfigConditionErrorSettingDefault condition. This
-// should be used in such a way that it voids previous errors
-// if any during setting of defaults against CStorClusterConfig.
-func MakeNoErrorSettingDefaultsCondition() map[string]string {
+// MakeNoReconcileErrorCondition builds a new no
+// CStorClusterConfigConditionReconcileError condition. This
+// should be used in such a way that it voids previous occurrence of
+// this error if any.
+func MakeNoReconcileErrorCondition() map[string]string {
 	return map[string]string{
-		"type":             string(CStorClusterConfigConditionErrorSettingDefaults),
+		"type":             string(CStorClusterConfigConditionReconcileError),
 		"status":           string(CStorClusterConfigConditionIsAbsent),
 		"lastObservedTime": time.Now().String(),
 	}
 }
 
-// SetNoErrorSettingDefaultsCondition sets
-// CStorClusterConfigConditionErrorSettingDefault condition to false.
-func SetNoErrorSettingDefaultsCondition(obj *CStorClusterConfig) {
+// MergeNoReconcileErrorOnCStorClusterConfig sets
+// CStorClusterConfigConditionReconcileError condition to false.
+func MergeNoReconcileErrorOnCStorClusterConfig(obj *CStorClusterConfig) {
 	noErrCond := CStorClusterConfigStatusCondition{
-		Type:             CStorClusterConfigConditionErrorSettingDefaults,
+		Type:             CStorClusterConfigConditionReconcileError,
 		Status:           CStorClusterConfigConditionIsAbsent,
 		LastObservedTime: metav1.Now(),
 	}
 	var newConds []CStorClusterConfigStatusCondition
 	for _, old := range obj.Status.Conditions {
-		if old.Type == CStorClusterConfigConditionErrorSettingDefaults {
+		if old.Type == CStorClusterConfigConditionReconcileError {
+			// ignore previous occurrence of ReconcileError
 			continue
 		}
 		newConds = append(newConds, old)

--- a/types/cstorclusterconfig.go
+++ b/types/cstorclusterconfig.go
@@ -19,7 +19,6 @@ package types
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	metac "openebs.io/metac/apis/metacontroller/v1alpha1"
 )
@@ -124,7 +123,6 @@ type ExternalProvisioner struct {
 type CStorClusterConfigStatus struct {
 	Phase      CStorClusterConfigStatusPhase       `json:"phase"`
 	Conditions []CStorClusterConfigStatusCondition `json:"conditions"`
-	Nodes      []CStorClusterConfigStatusNode      `json:"nodes"`
 }
 
 // CStorClusterConfigStatusPhase reports the current phase of
@@ -148,12 +146,4 @@ type CStorClusterConfigStatusCondition struct {
 	Status           CStorClusterConfigConditionStatus `json:"status"`
 	Reason           string                            `json:"reason,omitempty"`
 	LastObservedTime metav1.Time                       `json:"lastObservedTime"`
-}
-
-// CStorClusterConfigStatusNode represents the eligible node.
-// In other words this node is suitable to be used as a cstor
-// pool instance.
-type CStorClusterConfigStatusNode struct {
-	Name string    `json:"name"`
-	UID  types.UID `json:"uid"`
 }

--- a/types/cstorclusterconfig_plan.go
+++ b/types/cstorclusterconfig_plan.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// CStorClusterConfigPlan is a kubernetes custom resource that plans
+// the resources especially nodes to form the CStorPoolCluster
+type CStorClusterConfigPlan struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+
+	Spec CStorClusterConfigPlanSpec `json:"spec"`
+}
+
+// CStorClusterConfigPlanSpec has the plan details required to form
+// CStorPoolCluster
+type CStorClusterConfigPlanSpec struct {
+	ClusterConfigReference CStorClusterConfigReference  `json:"clusterConfigReference"`
+	Nodes                  []CStorClusterConfigPlanNode `json:"nodes"`
+}
+
+// CStorClusterConfigPlanNode has the node details that is used to
+// form CStorPoolCluster
+type CStorClusterConfigPlanNode struct {
+	Name string    `json:"name"`
+	UID  types.UID `json:"uid"`
+}
+
+// CStorClusterConfigReference refers to CStorClusterConfig
+// which is the trigger to CStorClusterPlan
+type CStorClusterConfigReference struct {
+	UID types.UID `json:"uid"`
+}


### PR DESCRIPTION
This commit adds a new custom resource known as CStorClusterConfigPlan. This removes the earlier logic of remembering desired nodes from CStorClusterConfig.status.

This resource will provide the nodes to be used to form CStorPoolCluster.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>