### PR TITLE
fix(status): use map[string]interface{} for status conditions

### DIFF
--- a/controller/blockdevice/reconciler.go
+++ b/controller/blockdevice/reconciler.go
@@ -210,10 +210,10 @@ func (r *Reconciler) getStorageStatusAsNoError() (map[string]interface{}, error)
 	// get updated conditions
 	conds, err := k8s.MergeStatusConditions(
 		r.Storage,
-		map[string]string{
-			"type":             string(types.StorageToBlockDeviceAssociationErrorCondition),
-			"status":           string(types.ConditionIsAbsent),
-			"lastObservedTime": metav1.Now().String(),
+		map[string]interface{}{
+			"type":             types.StorageToBlockDeviceAssociationErrorCondition,
+			"status":           types.ConditionIsAbsent,
+			"lastObservedTime": metav1.Now(),
 		},
 	)
 	if err != nil {

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -72,7 +72,7 @@ func GetNestedSlice(obj *unstructured.Unstructured, fields ...string) ([]interfa
 // updated slice.
 //
 // TODO (@amitkumardas): Unit Tests
-func MergeNestedSlice(obj *unstructured.Unstructured, new map[string]string, fields ...string) ([]interface{}, error) {
+func MergeNestedSlice(obj *unstructured.Unstructured, new map[string]interface{}, fields ...string) ([]interface{}, error) {
 	nestedSlice, err := GetNestedSlice(obj, fields...)
 	if err != nil {
 		return nil, err
@@ -91,19 +91,20 @@ func MergeNestedSlice(obj *unstructured.Unstructured, new map[string]string, fie
 		// the slice of maps.
 		if k == "uid" || k == "id" || k == "name" || k == "type" {
 			indexKey = k
-			indexValue = v
+			indexValue, _ = v.(string)
 			break
 		}
 	}
 	var found bool
 	var foundAt int
 	for i, item := range nestedSlice {
-		itemMap, ok := item.(map[string]string)
+		itemMap, ok := item.(map[string]interface{})
 		if !ok {
-			return nil, errors.Errorf("Invalid nested slice: Want map[string]string: Got %T", item)
+			return nil, errors.Errorf("Invalid nested slice: Want map[string]interface{}: Got %T", item)
 		}
 		for k, v := range itemMap {
-			if k == indexKey && v == indexValue {
+			val, _ := v.(string)
+			if k == indexKey && val == indexValue {
 				found = true
 				foundAt = i
 				break
@@ -126,7 +127,7 @@ func MergeNestedSlice(obj *unstructured.Unstructured, new map[string]string, fie
 // MergeAndSetNestedSlice merges the provided map against a slice
 // of maps at given field path. It then sets the updated slice against
 // the provided object.
-func MergeAndSetNestedSlice(obj *unstructured.Unstructured, new map[string]string, fields ...string) ([]interface{}, error) {
+func MergeAndSetNestedSlice(obj *unstructured.Unstructured, new map[string]interface{}, fields ...string) ([]interface{}, error) {
 	updatedSlice, err := MergeNestedSlice(obj, new, fields...)
 	if err != nil {
 		return nil, err
@@ -142,7 +143,7 @@ func MergeAndSetNestedSlice(obj *unstructured.Unstructured, new map[string]strin
 // ones if any & returns the updated conditions
 //
 // TODO (@amitkumardas): Unit Tests
-func MergeStatusConditions(obj *unstructured.Unstructured, newCondition map[string]string) ([]interface{}, error) {
+func MergeStatusConditions(obj *unstructured.Unstructured, newCondition map[string]interface{}) ([]interface{}, error) {
 	return MergeNestedSlice(obj, newCondition, "status", "conditions")
 }
 
@@ -150,7 +151,7 @@ func MergeStatusConditions(obj *unstructured.Unstructured, newCondition map[stri
 // ones if any against the provided object
 //
 // TODO (@amitkumardas): Unit Tests
-func MergeAndSetStatusConditions(obj *unstructured.Unstructured, newCondition map[string]string) ([]interface{}, error) {
+func MergeAndSetStatusConditions(obj *unstructured.Unstructured, newCondition map[string]interface{}) ([]interface{}, error) {
 	return MergeAndSetNestedSlice(obj, newCondition, "status", "conditions")
 }
 

--- a/types/status.go
+++ b/types/status.go
@@ -89,60 +89,60 @@ const (
 // MakeCStorClusterConfigReconcileErrCond builds a new
 // CStorClusterConfigConditionReconcileError condition
 // suitable to be used in API status.conditions
-func MakeCStorClusterConfigReconcileErrCond(err error) map[string]string {
-	return map[string]string{
-		"type":             string(CStorClusterConfigReconcileErrorCondition),
-		"status":           string(ConditionIsPresent),
+func MakeCStorClusterConfigReconcileErrCond(err error) map[string]interface{} {
+	return map[string]interface{}{
+		"type":             CStorClusterConfigReconcileErrorCondition,
+		"status":           ConditionIsPresent,
 		"reason":           err.Error(),
-		"lastObservedTime": metav1.Now().String(),
+		"lastObservedTime": metav1.Now(),
 	}
 }
 
 // MakeCStorClusterPlanReconcileErrCond builds a new
 // CStorClusterPlanConditionReconcileError condition
 // suitable to be used in API status.conditions
-func MakeCStorClusterPlanReconcileErrCond(err error) map[string]string {
-	return map[string]string{
-		"type":             string(CStorClusterPlanReconcileErrorCondition),
-		"status":           string(ConditionIsPresent),
+func MakeCStorClusterPlanReconcileErrCond(err error) map[string]interface{} {
+	return map[string]interface{}{
+		"type":             CStorClusterPlanReconcileErrorCondition,
+		"status":           ConditionIsPresent,
 		"reason":           err.Error(),
-		"lastObservedTime": metav1.Now().String(),
+		"lastObservedTime": metav1.Now(),
 	}
 }
 
 // MakeCStorClusterStorageSetReconcileErrCond builds a new
 // CStorClusterStorageSetConditionReconcileError condition
 // suitable to be used in API status.conditions
-func MakeCStorClusterStorageSetReconcileErrCond(err error) map[string]string {
-	return map[string]string{
-		"type":             string(CStorClusterStorageSetReconcileErrorCondition),
-		"status":           string(ConditionIsPresent),
+func MakeCStorClusterStorageSetReconcileErrCond(err error) map[string]interface{} {
+	return map[string]interface{}{
+		"type":             CStorClusterStorageSetReconcileErrorCondition,
+		"status":           ConditionIsPresent,
 		"reason":           err.Error(),
-		"lastObservedTime": metav1.Now().String(),
+		"lastObservedTime": metav1.Now(),
 	}
 }
 
 // MakeCStorClusterPlanCSPCApplyErrCond builds a new
 // CStorPoolClusterApplyErrorCondition suitable to be
 // used in API status.conditions
-func MakeCStorClusterPlanCSPCApplyErrCond(err error) map[string]string {
-	return map[string]string{
-		"type":             string(CStorClusterPlanCSPCApplyErrorCondition),
-		"status":           string(ConditionIsPresent),
+func MakeCStorClusterPlanCSPCApplyErrCond(err error) map[string]interface{} {
+	return map[string]interface{}{
+		"type":             CStorClusterPlanCSPCApplyErrorCondition,
+		"status":           ConditionIsPresent,
 		"reason":           err.Error(),
-		"lastObservedTime": metav1.Now().String(),
+		"lastObservedTime": metav1.Now(),
 	}
 }
 
 // MakeStorageToBlockDeviceAssociationErrCond builds a new
 // StorageToBlockDeviceAssociationErrorCondition suitable to
 // be used in API status.conditions
-func MakeStorageToBlockDeviceAssociationErrCond(err error) map[string]string {
-	return map[string]string{
-		"type":             string(StorageToBlockDeviceAssociationErrorCondition),
-		"status":           string(ConditionIsPresent),
+func MakeStorageToBlockDeviceAssociationErrCond(err error) map[string]interface{} {
+	return map[string]interface{}{
+		"type":             StorageToBlockDeviceAssociationErrorCondition,
+		"status":           ConditionIsPresent,
 		"reason":           err.Error(),
-		"lastObservedTime": metav1.Now().String(),
+		"lastObservedTime": metav1.Now(),
 	}
 }
 
@@ -150,11 +150,11 @@ func MakeStorageToBlockDeviceAssociationErrCond(err error) map[string]string {
 // CStorClusterConfigConditionReconcileError condition. This
 // should be used in such a way that it voids previous occurrence of
 // this error if any.
-func MakeNoCStorClusterConfigReconcileErrCond() map[string]string {
-	return map[string]string{
+func MakeNoCStorClusterConfigReconcileErrCond() map[string]interface{} {
+	return map[string]interface{}{
 		"type":             string(CStorClusterConfigReconcileErrorCondition),
 		"status":           string(ConditionIsAbsent),
-		"lastObservedTime": metav1.Now().String(),
+		"lastObservedTime": metav1.Now(),
 	}
 }
 


### PR DESCRIPTION
This commit should fix the issue of unmarshalling objects when status.conditions made use of lastObservedTime in string format. 

This should also fix the issue of unable to merge status conditions since unstructured instances from kubernetes always comes up as map[string]interface{}.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>