### PR TITLE
fix(time): set metav1.Time to string format

### DIFF
--- a/controller/blockdevice/reconciler.go
+++ b/controller/blockdevice/reconciler.go
@@ -91,7 +91,16 @@ func (h *reconcileErrHandler) handle(err error) {
 // controller to run continuously. Hence, the errors are logged and at
 // the same time, these errors are posted against Storage's status field.
 func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) error {
-	response = &generic.SyncHookResponse{}
+	if request == nil {
+		return errors.Errorf(
+			"Failed to associate BlockDevice with Storage: Nil request found",
+		)
+	}
+	if response == nil {
+		return errors.Errorf(
+			"Failed to associate BlockDevice with Storage: Nil response found",
+		)
+	}
 
 	// construct the error handler
 	errHandler := &reconcileErrHandler{

--- a/controller/cstorclusterplan/reconciler.go
+++ b/controller/cstorclusterplan/reconciler.go
@@ -89,7 +89,12 @@ func (h *reconcileErrHandler) handle(err error) {
 // the same time, these errors are posted against CStorClusterPlan's
 // status.
 func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) error {
-	response = &generic.SyncHookResponse{}
+	if request == nil {
+		return errors.Errorf("Failed to reconcile CStorClusterPlan: Nil request found")
+	}
+	if response == nil {
+		return errors.Errorf("Failed to reconcile CStorClusterPlan: Nil response found")
+	}
 
 	// construct the error handler
 	errHandler := &reconcileErrHandler{

--- a/controller/cstorclusterstorageset/reconciler.go
+++ b/controller/cstorclusterstorageset/reconciler.go
@@ -92,7 +92,12 @@ func (h *reconcileErrHandler) handle(err error) {
 // the same time, these errors are posted against CStorClusterStorageSet
 // status.
 func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) error {
-	response = &generic.SyncHookResponse{}
+	if request == nil {
+		return errors.Errorf("Failed to reconcile CStorClusterStorageSet: Nil request found")
+	}
+	if response == nil {
+		return errors.Errorf("Failed to reconcile CStorClusterStorageSet: Nil response found")
+	}
 
 	// construct the error handler
 	errHandler := &reconcileErrHandler{

--- a/controller/cstorpoolcluster/reconciler.go
+++ b/controller/cstorpoolcluster/reconciler.go
@@ -93,7 +93,16 @@ func (h *reconcileErrHandler) handle(err error) {
 // the same time, these errors are posted against the watch here
 // CStorClusterPlan status conditions.
 func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) error {
-	response = &generic.SyncHookResponse{}
+	if request == nil {
+		return errors.Errorf(
+			"Failed to apply CStorPoolCluster for CStorClusterPlan: Nil request found",
+		)
+	}
+	if response == nil {
+		return errors.Errorf(
+			"Failed to apply CStorPoolCluster for CStorClusterPlan: Nil response found",
+		)
+	}
 
 	// construct the error handler
 	errHandler := &reconcileErrHandler{

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -17,6 +17,8 @@ limitations under the License.
 package k8s
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -91,7 +93,7 @@ func MergeNestedSlice(obj *unstructured.Unstructured, new map[string]interface{}
 		// the slice of maps.
 		if k == "uid" || k == "id" || k == "name" || k == "type" {
 			indexKey = k
-			indexValue, _ = v.(string)
+			indexValue = fmt.Sprintf("%s", v)
 			break
 		}
 	}
@@ -103,7 +105,7 @@ func MergeNestedSlice(obj *unstructured.Unstructured, new map[string]interface{}
 			return nil, errors.Errorf("Invalid nested slice: Want map[string]interface{}: Got %T", item)
 		}
 		for k, v := range itemMap {
-			val, _ := v.(string)
+			val := fmt.Sprintf("%s", v)
 			if k == indexKey && val == indexValue {
 				found = true
 				foundAt = i

--- a/types/cstorclusterconfig.go
+++ b/types/cstorclusterconfig.go
@@ -145,5 +145,5 @@ type CStorClusterConfigStatusCondition struct {
 	Type             ConditionType  `json:"type"`
 	Status           ConditionState `json:"status"`
 	Reason           string         `json:"reason,omitempty"`
-	LastObservedTime metav1.Time    `json:"lastObservedTime"`
+	LastObservedTime string         `json:"lastObservedTime"`
 }

--- a/types/cstorclusterplan.go
+++ b/types/cstorclusterplan.go
@@ -77,5 +77,5 @@ type CStorClusterPlanStatusCondition struct {
 	Type             ConditionType  `json:"type"`
 	Status           ConditionState `json:"status"`
 	Reason           string         `json:"reason,omitempty"`
-	LastObservedTime metav1.Time    `json:"lastObservedTime"`
+	LastObservedTime string         `json:"lastObservedTime"`
 }

--- a/types/cstorclusterstorageset.go
+++ b/types/cstorclusterstorageset.go
@@ -74,5 +74,5 @@ type CStorClusterStorageSetStatusCondition struct {
 	Type             ConditionType  `json:"type"`
 	Status           ConditionState `json:"status"`
 	Reason           string         `json:"reason,omitempty"`
-	LastObservedTime metav1.Time    `json:"lastObservedTime"`
+	LastObservedTime string         `json:"lastObservedTime"`
 }

--- a/types/status.go
+++ b/types/status.go
@@ -86,6 +86,12 @@ const (
 	BlockDeviceUnclaimed DeviceClaimState = "Unclaimed"
 )
 
+// now returns the current time in following format
+// 2006-01-02 15:04:05.000000
+func now() string {
+	return metav1.Now().Format("2006-01-02 15:04:05.000000")
+}
+
 // MakeCStorClusterConfigReconcileErrCond builds a new
 // CStorClusterConfigConditionReconcileError condition
 // suitable to be used in API status.conditions
@@ -94,7 +100,7 @@ func MakeCStorClusterConfigReconcileErrCond(err error) map[string]interface{} {
 		"type":             CStorClusterConfigReconcileErrorCondition,
 		"status":           ConditionIsPresent,
 		"reason":           err.Error(),
-		"lastObservedTime": metav1.Now(),
+		"lastObservedTime": now(),
 	}
 }
 
@@ -106,7 +112,7 @@ func MakeCStorClusterPlanReconcileErrCond(err error) map[string]interface{} {
 		"type":             CStorClusterPlanReconcileErrorCondition,
 		"status":           ConditionIsPresent,
 		"reason":           err.Error(),
-		"lastObservedTime": metav1.Now(),
+		"lastObservedTime": now(),
 	}
 }
 
@@ -118,7 +124,7 @@ func MakeCStorClusterStorageSetReconcileErrCond(err error) map[string]interface{
 		"type":             CStorClusterStorageSetReconcileErrorCondition,
 		"status":           ConditionIsPresent,
 		"reason":           err.Error(),
-		"lastObservedTime": metav1.Now(),
+		"lastObservedTime": now(),
 	}
 }
 
@@ -130,7 +136,7 @@ func MakeCStorClusterPlanCSPCApplyErrCond(err error) map[string]interface{} {
 		"type":             CStorClusterPlanCSPCApplyErrorCondition,
 		"status":           ConditionIsPresent,
 		"reason":           err.Error(),
-		"lastObservedTime": metav1.Now(),
+		"lastObservedTime": now(),
 	}
 }
 
@@ -142,7 +148,7 @@ func MakeStorageToBlockDeviceAssociationErrCond(err error) map[string]interface{
 		"type":             StorageToBlockDeviceAssociationErrorCondition,
 		"status":           ConditionIsPresent,
 		"reason":           err.Error(),
-		"lastObservedTime": metav1.Now(),
+		"lastObservedTime": now(),
 	}
 }
 
@@ -154,7 +160,7 @@ func MakeNoCStorClusterConfigReconcileErrCond() map[string]interface{} {
 	return map[string]interface{}{
 		"type":             string(CStorClusterConfigReconcileErrorCondition),
 		"status":           string(ConditionIsAbsent),
-		"lastObservedTime": metav1.Now(),
+		"lastObservedTime": now(),
 	}
 }
 
@@ -164,7 +170,7 @@ func MergeNoReconcileErrorOnCStorClusterConfig(obj *CStorClusterConfig) {
 	noErrCond := CStorClusterConfigStatusCondition{
 		Type:             CStorClusterConfigReconcileErrorCondition,
 		Status:           ConditionIsAbsent,
-		LastObservedTime: metav1.Now(),
+		LastObservedTime: now(),
 	}
 	var newConds []CStorClusterConfigStatusCondition
 	for _, old := range obj.Status.Conditions {
@@ -184,7 +190,7 @@ func MergeNoReconcileErrorOnCStorClusterPlan(obj *CStorClusterPlan) {
 	noErrCond := CStorClusterPlanStatusCondition{
 		Type:             CStorClusterPlanReconcileErrorCondition,
 		Status:           ConditionIsAbsent,
-		LastObservedTime: metav1.Now(),
+		LastObservedTime: now(),
 	}
 	var newConds []CStorClusterPlanStatusCondition
 	for _, old := range obj.Status.Conditions {
@@ -204,7 +210,7 @@ func MergeNoCSPCApplyErrorOnCStorClusterPlan(obj *CStorClusterPlan) {
 	noErrCond := CStorClusterPlanStatusCondition{
 		Type:             CStorClusterPlanCSPCApplyErrorCondition,
 		Status:           ConditionIsAbsent,
-		LastObservedTime: metav1.Now(),
+		LastObservedTime: now(),
 	}
 	var newConds []CStorClusterPlanStatusCondition
 	for _, old := range obj.Status.Conditions {
@@ -224,7 +230,7 @@ func MergeNoReconcileErrorOnCStorClusterStorageSet(obj *CStorClusterStorageSet) 
 	noErrCond := CStorClusterStorageSetStatusCondition{
 		Type:             CStorClusterStorageSetReconcileErrorCondition,
 		Status:           ConditionIsAbsent,
-		LastObservedTime: metav1.Now(),
+		LastObservedTime: now(),
 	}
 	var newConds []CStorClusterStorageSetStatusCondition
 	for _, old := range obj.Status.Conditions {


### PR DESCRIPTION
This commit changes the datatype of time to string format to avoid unmarshal errors. We might want to revist the exact time format based on production needs.

In addition, this change has the fixes to throw error if either hook request or hook response is nil.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>