### PR TITLE
fix(reconcile): add kind when creating desired instances

### DIFF
--- a/controller/blockdevice/reconciler.go
+++ b/controller/blockdevice/reconciler.go
@@ -40,7 +40,7 @@ func (h *reconcileErrHandler) handle(err error) {
 	//
 	// In addition, errors are logged as well.
 	glog.Errorf(
-		"Failed to associate a BlockDevice with Storage %s %s: %v",
+		"Failed to associate a BlockDevice with Storage %s %s: %+v",
 		h.storage.GetNamespace(), h.storage.GetName(), err,
 	)
 
@@ -51,7 +51,7 @@ func (h *reconcileErrHandler) handle(err error) {
 		)
 	if mergeErr != nil {
 		glog.Errorf(
-			"Can't set status conditions on Storage %s %s: %v",
+			"Can't set status conditions on Storage %s %s: %+v",
 			h.storage.GetNamespace(), h.storage.GetName(), mergeErr,
 		)
 		// Note: Merge error will reset the conditions which will make
@@ -111,11 +111,11 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 	var cstorClusterStoragetSet *unstructured.Unstructured
 	var pvc *unstructured.Unstructured
 	for _, attachment := range request.Attachments.List() {
-		if attachment.GetKind() == string(k8s.KindBlockDevice) {
+		if attachment.GetKind() == string(types.KindBlockDevice) {
 			// BlockDevices are attached after the reconciliation
 			continue
 		}
-		if attachment.GetKind() == string(k8s.KindCStorClusterStorageSet) {
+		if attachment.GetKind() == string(types.KindCStorClusterStorageSet) {
 			// verify further if this belongs to the current watch
 			uid, _ := k8s.GetAnnotationForKey(
 				request.Watch.GetAnnotations(), types.AnnKeyCStorClusterStorageSetUID,
@@ -125,7 +125,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 				cstorClusterStoragetSet = attachment
 			}
 		}
-		if attachment.GetKind() == string(k8s.KindPersistentVolumeClaim) {
+		if attachment.GetKind() == string(types.KindPersistentVolumeClaim) {
 			// verify further if this belongs to the current watch
 			uid, _ := k8s.GetAnnotationForKey(
 				attachment.GetAnnotations(), types.AnnKeyStorageUID,
@@ -291,7 +291,7 @@ func (p *StorageToBlockDeviceAssociator) Associate() ([]*unstructured.Unstructur
 func (p *StorageToBlockDeviceAssociator) getObservedBlockDevices() []*unstructured.Unstructured {
 	var blockDevices []*unstructured.Unstructured
 	for _, resource := range p.ObservedResources {
-		if resource.GetKind() == string(k8s.KindBlockDevice) {
+		if resource.GetKind() == string(types.KindBlockDevice) {
 			blockDevices = append(blockDevices, resource)
 		}
 	}

--- a/controller/cstorclusterconfig/node.go
+++ b/controller/cstorclusterconfig/node.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cstorclusterconfig
 
 import (
-	"cstorpoolauto/k8s"
 	"cstorpoolauto/types"
 	"sort"
 
@@ -205,7 +204,7 @@ type NodePlannerConfig struct {
 func (s *NodePlanner) GetAllNodes() []*unstructured.Unstructured {
 	var nodes []*unstructured.Unstructured
 	for _, attachment := range s.Resources {
-		if attachment.GetKind() == string(k8s.KindNode) {
+		if attachment.GetKind() == string(types.KindNode) {
 			nodes = append(nodes, attachment)
 		}
 	}

--- a/controller/cstorclusterplan/reconciler.go
+++ b/controller/cstorclusterplan/reconciler.go
@@ -40,7 +40,7 @@ func (h *reconcileErrHandler) handle(err error) {
 	//
 	// In addition, errors are logged as well.
 	glog.Errorf(
-		"Failed to reconcile CStorClusterPlan %s %s: %v",
+		"Failed to reconcile CStorClusterPlan %s %s: %+v",
 		h.clusterPlan.GetNamespace(), h.clusterPlan.GetName(), err,
 	)
 
@@ -51,7 +51,7 @@ func (h *reconcileErrHandler) handle(err error) {
 		)
 	if mergeErr != nil {
 		glog.Errorf(
-			"Failed to reconcile CStorClusterPlan %s %s: Can't set status conditions: %v",
+			"Failed to reconcile CStorClusterPlan %s %s: Can't set status conditions: %+v",
 			h.clusterPlan.GetNamespace(), h.clusterPlan.GetName(), mergeErr,
 		)
 		// Note: Merge error will reset the conditions which will make
@@ -109,7 +109,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 		request.Watch.GetAnnotations(), types.AnnKeyCStorClusterConfigUID,
 	)
 	for _, attachment := range request.Attachments.List() {
-		if attachment.GetKind() == string(k8s.KindCStorClusterStorageSet) {
+		if attachment.GetKind() == string(types.KindCStorClusterStorageSet) {
 			// verify further if CStorClusterStorageSet belongs to current watch
 			uid, _ := k8s.GetAnnotationForKey(
 				attachment.GetAnnotations(), types.AnnKeyCStorClusterPlanUID,
@@ -122,7 +122,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 				continue
 			}
 		}
-		if attachment.GetKind() == string(k8s.KindCStorClusterConfig) {
+		if attachment.GetKind() == string(types.KindCStorClusterConfig) {
 			// verify further if CStorClusterConfig belongs to current watch
 			if string(attachment.GetUID()) == desiredCStorClusterConfigUID {
 				// this is a desired CStorClusterConfig
@@ -364,8 +364,8 @@ func (p *StorageSetsPlanner) create(config *types.CStorClusterConfig) []*unstruc
 		storageSet := &unstructured.Unstructured{}
 		storageSet.SetUnstructuredContent(map[string]interface{}{
 			"metadata": map[string]interface{}{
-				"apiVersion":   "dao.mayadata.io/v1alpha1",
-				"kind":         "CStorClusterStorageSet",
+				"apiVersion":   string(types.APIVersionDAOMayaDataV1Alpha1),
+				"kind":         string(types.KindCStorClusterStorageSet),
 				"generateName": "ccplan-", // ccplan -> CStorClusterPlan
 				"namespace":    p.ClusterPlan.GetNamespace(),
 				"annotations": map[string]interface{}{

--- a/controller/cstorclusterstorageset/reconciler.go
+++ b/controller/cstorclusterstorageset/reconciler.go
@@ -42,7 +42,7 @@ func (h *reconcileErrHandler) handle(err error) {
 	//
 	// In addition, errors are logged as well.
 	glog.Errorf(
-		"Failed to reconcile CStorClusterStorageSet %s %s: %v",
+		"Failed to reconcile CStorClusterStorageSet %s %s: %+v",
 		h.storageSet.GetNamespace(), h.storageSet.GetName(), err,
 	)
 
@@ -53,7 +53,7 @@ func (h *reconcileErrHandler) handle(err error) {
 		)
 	if mergeErr != nil {
 		glog.Errorf(
-			"Failed to reconcile CStorClusterStorageSet %s %s: Can't set status conditions: %v",
+			"Failed to reconcile CStorClusterStorageSet %s %s: Can't set status conditions: %+v",
 			h.storageSet.GetNamespace(), h.storageSet.GetName(), mergeErr,
 		)
 		// Note: Merge error will reset the conditions which will make
@@ -107,7 +107,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 
 	var observedStorages []*unstructured.Unstructured
 	for _, attachment := range request.Attachments.List() {
-		if attachment.GetKind() == string(k8s.KindStorage) {
+		if attachment.GetKind() == string(types.KindStorage) {
 			// verify further if this belongs to the current watch
 			uid, _ := k8s.GetAnnotationForKey(
 				attachment.GetAnnotations(), types.AnnKeyCStorClusterStorageSetUID,
@@ -264,8 +264,8 @@ func (p *StoragePlanner) create(count int64) []*unstructured.Unstructured {
 		new := &unstructured.Unstructured{}
 		new.SetUnstructuredContent(map[string]interface{}{
 			"metadata": map[string]interface{}{
-				"apiVersion":   "dao.mayadata.io/v1alpha1",
-				"kind":         "Storage",
+				"apiVersion":   string(types.APIVersionDAOMayaDataV1Alpha1),
+				"kind":         string(types.KindStorage),
 				"generateName": "ccsset-", // ccsset -> CStorClusterStorageSet
 				"namespace":    p.DesiredNamespace,
 				"annotations": map[string]interface{}{

--- a/controller/cstorpoolcluster/reconciler.go
+++ b/controller/cstorpoolcluster/reconciler.go
@@ -43,7 +43,7 @@ func (h *reconcileErrHandler) handle(err error) {
 	//
 	// In addition, errors are logged as well.
 	glog.Errorf(
-		"Failed to apply CStorPoolCluster for CStorClusterPlan %s %s: %v",
+		"Failed to apply CStorPoolCluster for CStorClusterPlan %s %s: %+v",
 		h.clusterPlan.GetNamespace(), h.clusterPlan.GetName(), err,
 	)
 
@@ -53,7 +53,7 @@ func (h *reconcileErrHandler) handle(err error) {
 		)
 	if mergeErr != nil {
 		glog.Errorf(
-			"Can't set status conditions for CStorClusterPlan %s %s: %v",
+			"Can't set status conditions for CStorClusterPlan %s %s: %+v",
 			h.clusterPlan.GetNamespace(), h.clusterPlan.GetName(), mergeErr,
 		)
 		// Note: Merge error will reset the conditions which will make
@@ -115,7 +115,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 	var observedBlockDevices []*unstructured.Unstructured
 	var observedStorageSets []*unstructured.Unstructured
 	for _, attachment := range request.Attachments.List() {
-		if attachment.GetKind() == string(k8s.KindCStorPoolCluster) {
+		if attachment.GetKind() == string(types.KindCStorPoolCluster) {
 			// verify further if this belongs to the current watch
 			// i.e. CStorClusterPlan
 			uid, _ := k8s.GetAnnotationForKey(
@@ -129,7 +129,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 				continue
 			}
 		}
-		if attachment.GetKind() == string(k8s.KindBlockDevice) {
+		if attachment.GetKind() == string(types.KindBlockDevice) {
 			// verify further if this belongs to the current watch
 			// i.e. CStorClusterPlan
 			uid, _ := k8s.GetAnnotationForKey(
@@ -140,7 +140,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 				observedBlockDevices = append(observedBlockDevices, attachment)
 			}
 		}
-		if attachment.GetKind() == string(k8s.KindCStorClusterStorageSet) {
+		if attachment.GetKind() == string(types.KindCStorClusterStorageSet) {
 			// verify further if this belongs to the current watch
 			// i.e. CStorClusterPlan
 			uid, _ := k8s.GetAnnotationForKey(
@@ -151,7 +151,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 				observedStorageSets = append(observedStorageSets, attachment)
 			}
 		}
-		if attachment.GetKind() == string(k8s.KindCStorClusterConfig) {
+		if attachment.GetKind() == string(types.KindCStorClusterConfig) {
 			// verify further if this belongs to the current watch
 			// i.e. CStorClusterPlan
 			uid, _ := k8s.GetAnnotationForKey(
@@ -540,8 +540,8 @@ func (p *Planner) Plan() (*unstructured.Unstructured, error) {
 	desired := &unstructured.Unstructured{}
 	desired.SetUnstructuredContent(map[string]interface{}{
 		"metadata": map[string]interface{}{
-			"apiVersion": "openebs.io/v1alpha1",
-			"kind":       "CStorPoolCluster",
+			"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+			"kind":       string(types.KindCStorPoolCluster),
 			"name":       p.CStorClusterPlan.GetName(),
 			"namespace":  p.CStorClusterPlan.GetNamespace(),
 			"annotations": map[string]interface{}{

--- a/demo/basic/basic.yaml
+++ b/demo/basic/basic.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
     diskConfig:
         externalProvisioner:
-            csiAttacherName:
-            storageClassName:
+            csiAttacherName: pd.csi.storage.gke.io
+            storageClassName: csi-gce-pd
     poolConfig:
         raidType: mirror

--- a/demo/basic/gpd_sc.yaml
+++ b/demo/basic/gpd_sc.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-gce-pd
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: pd-standard

--- a/demo/basic/test.sh
+++ b/demo/basic/test.sh
@@ -9,6 +9,8 @@ cleanup() {
   echo "++ Clean up started"
   echo "--------------------------"
 
+
+  kubectl delete -f basic.yaml || true
   kubectl delete -f ../../deploy/operator.yaml || true
   kubectl delete -f ../../deploy/rbac.yaml || true
   kubectl delete -f ../../deploy/crd.yaml || true
@@ -21,7 +23,9 @@ cleanup() {
   
   kubectl delete -f openebs-operator-1.5.0.yaml || true
   kubectl delete -f cspc-operator.yaml || true
-  
+
+  kubectl delete -f gpd_sc.yaml || true
+
   echo "--------------------------"
   echo "++ Clean up completed"
   echo "--------------------------"
@@ -37,6 +41,10 @@ kubectl apply -f ../../deploy/crd.yaml
 kubectl apply -f ../../deploy/rbac.yaml
 kubectl apply -f ../../deploy/operator.yaml
 echo -e "\n++ Installed cstorpoolauto operator successfully"
+
+echo -e "\n++ Installing gpd storageclass"
+kubectl apply -f gpd_sc.yaml
+echo -e "\n++ Installed gpd storageclass successfully"
 
 echo -e "\n++ Installing storage-provisioner operator"
 curl https://raw.githubusercontent.com/mayadata-io/storage-provisioner/master/deploy/kubernetes/storage_crd.yaml > storage_crd.yaml

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -23,42 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// Kind is a custom datatype to refer to kubernetes native
-// resource kind value
-type Kind string
-
-const (
-	// KindNode refers to kubernetes node (a native resource)
-	// kind value
-	KindNode Kind = "Node"
-
-	// KindCStorClusterPlan refers to custom resource with
-	// kind CStorClusterPlan
-	KindCStorClusterPlan Kind = "CStorClusterPlan"
-
-	// KindCStorClusterStorageSet refers to custom resource with
-	// kind CStorClusterStorageSet
-	KindCStorClusterStorageSet Kind = "CStorClusterStorageSet"
-
-	// KindCStorClusterConfig refers to custom resource with
-	// kind CStorClusterConfig
-	KindCStorClusterConfig Kind = "CStorClusterConfig"
-
-	// KindStorage refers to custom resource with kind Storage
-	KindStorage Kind = "Storage"
-
-	// KindBlockDevice refers to custom resource with kind BlockDevice
-	KindBlockDevice Kind = "BlockDevice"
-
-	// KindPersistentVolumeClaim refers to custom resource with kind
-	// PersistentVolumeClaim
-	KindPersistentVolumeClaim Kind = "PersistentVolumeClaim"
-
-	// KindCStorPoolCluster refers to custom resource with kind
-	// CStorPoolCluster
-	KindCStorPoolCluster Kind = "CStorPoolCluster"
-)
-
 // GetNestedSlice returns the slice found at given field path
 // of the given object
 func GetNestedSlice(obj *unstructured.Unstructured, fields ...string) ([]interface{}, error) {

--- a/types/gvk.go
+++ b/types/gvk.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+const (
+	// GroupDAOMayaDataIO refers to the group for all
+	// custom resources defined in this project
+	GroupDAOMayaDataIO string = "dao.mayadata.io"
+
+	// VersionV1Alpha1 refers to v1alpha1 version of the
+	// custom resources used here
+	VersionV1Alpha1 string = "v1alpha1"
+
+	// APIVersionDAOMayaDataV1Alpha1 refers to v1alpha1 api
+	// version of DAO based custom resources
+	APIVersionDAOMayaDataV1Alpha1 string = "dao.mayadata.io/v1alpha1"
+
+	// APIVersionOpenEBSV1Alpha1 refers to v1alpha1 api
+	// version of openebs based custom resources
+	APIVersionOpenEBSV1Alpha1 string = "openebs.io/v1alpha1"
+)
+
+// Kind is a custom datatype to refer to kubernetes native
+// resource kind value
+type Kind string
+
+const (
+	// KindNode refers to kubernetes node (a native resource)
+	// kind value
+	KindNode Kind = "Node"
+
+	// KindCStorClusterPlan refers to custom resource with
+	// kind CStorClusterPlan
+	KindCStorClusterPlan Kind = "CStorClusterPlan"
+
+	// KindCStorClusterStorageSet refers to custom resource with
+	// kind CStorClusterStorageSet
+	KindCStorClusterStorageSet Kind = "CStorClusterStorageSet"
+
+	// KindCStorClusterConfig refers to custom resource with
+	// kind CStorClusterConfig
+	KindCStorClusterConfig Kind = "CStorClusterConfig"
+
+	// KindStorage refers to custom resource with kind Storage
+	KindStorage Kind = "Storage"
+
+	// KindBlockDevice refers to custom resource with kind BlockDevice
+	KindBlockDevice Kind = "BlockDevice"
+
+	// KindPersistentVolumeClaim refers to custom resource with kind
+	// PersistentVolumeClaim
+	KindPersistentVolumeClaim Kind = "PersistentVolumeClaim"
+
+	// KindCStorPoolCluster refers to custom resource with kind
+	// CStorPoolCluster
+	KindCStorPoolCluster Kind = "CStorPoolCluster"
+)


### PR DESCRIPTION
This commit adds kind and other required properties to any instance that gets created via this operator.

In addition, kind, group and version are moved to types package. Finally, verbose error logging is enabled that should print the stack trace in the logs.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>