### PR TITLE
fix(json): use apimachinery json package

### DIFF
--- a/controller/cstorclusterplan/reconciler.go
+++ b/controller/cstorclusterplan/reconciler.go
@@ -17,11 +17,10 @@ limitations under the License.
 package cstorclusterplan
 
 import (
-	"encoding/json"
-
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
 	"openebs.io/metac/controller/generic"
 
 	"cstorpoolauto/k8s"

--- a/controller/cstorclusterstorageset/reconciler.go
+++ b/controller/cstorclusterstorageset/reconciler.go
@@ -17,13 +17,12 @@ limitations under the License.
 package cstorclusterstorageset
 
 import (
-	"encoding/json"
-
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
 	"openebs.io/metac/controller/generic"
 
 	"cstorpoolauto/k8s"

--- a/controller/cstorpoolcluster/reconciler.go
+++ b/controller/cstorpoolcluster/reconciler.go
@@ -17,12 +17,11 @@ limitations under the License.
 package cstorpoolcluster
 
 import (
-	"encoding/json"
-
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
 	"openebs.io/metac/controller/generic"
 
 	"cstorpoolauto/k8s"


### PR DESCRIPTION
This commit uses apimachinery's json package instead of default json package. This should ensure unstructured instances are unmarshaled properly.

In addition, this commit fixes the logic to merge status conditions when status itself is nil.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>