### PR TITLE
fix(unmarshal): use reference instead of pointer

### DIFF
--- a/controller/cstorclusterconfig/reconciler.go
+++ b/controller/cstorclusterconfig/reconciler.go
@@ -233,13 +233,13 @@ func NewReconciler(
 	}
 
 	// transform CStorClusterPlan from unstructured to typed
-	var cstorClusterPlanTyped *types.CStorClusterPlan
+	var cstorClusterPlanTyped types.CStorClusterPlan
 	if clusterPlan != nil {
 		cstorClusterPlanRaw, err := clusterPlan.MarshalJSON()
 		if err != nil {
 			return nil, errors.Wrapf(err, "Can't marshal CStorClusterPlan")
 		}
-		err = json.Unmarshal(cstorClusterPlanRaw, cstorClusterPlanTyped)
+		err = json.Unmarshal(cstorClusterPlanRaw, &cstorClusterPlanTyped)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Can't unmarshal CStorClusterPlan")
 		}
@@ -247,7 +247,7 @@ func NewReconciler(
 
 	return &Reconciler{
 		CStorClusterConfig: &cstorClusterConfigTyped,
-		CStorClusterPlan:   cstorClusterPlanTyped,
+		CStorClusterPlan:   &cstorClusterPlanTyped,
 		Resources:          resources,
 		NodePlanner: &NodePlanner{
 			NodeSelector: cstorClusterConfigTyped.Spec.AllowedNodes,

--- a/controller/cstorclusterplan/reconciler.go
+++ b/controller/cstorclusterplan/reconciler.go
@@ -173,29 +173,29 @@ func NewReconciler(
 	observedStorageSets []*unstructured.Unstructured,
 ) (*Reconciler, error) {
 	// transforms cluster plan from unstructured to typed
-	var cstorClusterPlanTyped *types.CStorClusterPlan
+	var cstorClusterPlanTyped types.CStorClusterPlan
 	cstorClusterPlanRaw, err := clusterPlan.MarshalJSON()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Can't marshal CStorClusterPlan")
 	}
-	err = json.Unmarshal(cstorClusterPlanRaw, cstorClusterPlanTyped)
+	err = json.Unmarshal(cstorClusterPlanRaw, &cstorClusterPlanTyped)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Can't unmarshal CStorClusterPlan")
 	}
 	// transforms cluster config from unstructured to typed
-	var cstorClusterConfigTyped *types.CStorClusterConfig
+	var cstorClusterConfigTyped types.CStorClusterConfig
 	cstorClusterConfigRaw, err := clusterConfig.MarshalJSON()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Can't marshal CStorClusterConfig")
 	}
-	err = json.Unmarshal(cstorClusterConfigRaw, cstorClusterConfigTyped)
+	err = json.Unmarshal(cstorClusterConfigRaw, &cstorClusterConfigTyped)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Can't unmarshal CStorClusterConfig")
 	}
 	// use above constructed objects to build Reconciler instance
 	return &Reconciler{
-		CStorClusterPlan:    cstorClusterPlanTyped,
-		CStorClusterConfig:  cstorClusterConfigTyped,
+		CStorClusterPlan:    &cstorClusterPlanTyped,
+		CStorClusterConfig:  &cstorClusterConfigTyped,
 		ObservedStorageSets: observedStorageSets,
 	}, nil
 }

--- a/controller/cstorclusterstorageset/reconciler.go
+++ b/controller/cstorclusterstorageset/reconciler.go
@@ -157,18 +157,18 @@ func NewReconciler(
 	observedStorages []*unstructured.Unstructured,
 ) (*Reconciler, error) {
 	// transform storageset from unstructured to typed
-	var cstorClusterStorageSetTyped *types.CStorClusterStorageSet
+	var cstorClusterStorageSetTyped types.CStorClusterStorageSet
 	cstorClusterStorageSetRaw, err := storageSet.MarshalJSON()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Can't marshal CStorClusterStorageSet")
 	}
-	err = json.Unmarshal(cstorClusterStorageSetRaw, cstorClusterStorageSetTyped)
+	err = json.Unmarshal(cstorClusterStorageSetRaw, &cstorClusterStorageSetTyped)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Can't unmarshal CStorClusterStorageSet")
 	}
 	// use above constructed object to build Reconciler instance
 	return &Reconciler{
-		CStorClusterStorageSet: cstorClusterStorageSetTyped,
+		CStorClusterStorageSet: &cstorClusterStorageSetTyped,
 		ObservedStorages:       observedStorages,
 	}, nil
 }

--- a/controller/cstorpoolcluster/reconciler.go
+++ b/controller/cstorpoolcluster/reconciler.go
@@ -227,18 +227,18 @@ type ReconcileResponse struct {
 // NewReconciler returns a new instance of reconciler
 func NewReconciler(conf ReconcilerConfig) (*Reconciler, error) {
 	// transform CStorClusterPlan from unstructured to typed
-	var cstorClusterPlanTyped *types.CStorClusterPlan
+	var cstorClusterPlanTyped types.CStorClusterPlan
 	cstorClusterPlanRaw, err := conf.CStorClusterPlan.MarshalJSON()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Can't marshal CStorClusterPlan")
 	}
-	err = json.Unmarshal(cstorClusterPlanRaw, cstorClusterPlanTyped)
+	err = json.Unmarshal(cstorClusterPlanRaw, &cstorClusterPlanTyped)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Can't unmarshal CStorClusterPlan")
 	}
 	// use above constructed object to build Reconciler instance
 	return &Reconciler{
-		CStorClusterPlan:        cstorClusterPlanTyped,
+		CStorClusterPlan:        &cstorClusterPlanTyped,
 		DesiredCStorPoolCluster: conf.DesiredCStorPoolCluster,
 		ObservedClusterConfig:   conf.ObservedClusterConfig,
 		ObservedStorageSets:     conf.ObservedStorageSets,


### PR DESCRIPTION
This commit makes use of reference instead of pointer to unmarshal any object. This should fix similar errors like following:

json: Unmarshal(nil *types.CStorClusterPlan)

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>