### PR TITLE
fix(config): set updateAny tunable in the config file

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -4,6 +4,7 @@ metadata:
   name: sync-cstorclusterconfig
   namespace: cstorpoolauto
 spec:
+  updateAny: true
   watch:
     apiVersion: dao.mayadata.io/v1alpha1
     resource: cstorclusterconfigs
@@ -61,6 +62,7 @@ metadata:
   name: sync-blockdevice
   namespace: cstorpoolauto
 spec:
+  updateAny: true
   watch:
     apiVersion: dao.mayadata.io/v1alpha1
     resource: storages


### PR DESCRIPTION
This commit sets updateAny to true for specific metac controllers based on the controller's reconciliation logic.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>