### PR TITLE
fix(config): set updateStrategy to InPlace against desired resources

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -13,6 +13,8 @@ spec:
     resource: cstorclusterplans
   - apiVersion: dao.mayadata.io/v1alpha1
     resource: cstorclusterconfigs
+    updateStrategy:
+      method: InPlace
   - apiVersion: v1
     resource: nodes
   hooks:
@@ -71,6 +73,8 @@ spec:
     resource: cstorclusterstoragesets
   - apiVersion: openebs.io/v1alpha1
     resource: blockdevices
+    updateStrategy:
+      method: InPlace
   - apiVersion: v1
     resource: persistentvolumeclaims
   hooks:


### PR DESCRIPTION
This commit sets update stratgey to 'InPlace' against resources that controllers want to update. InPlace implies the same resource instance gets updated.

NOTE: Earlier this was not set that in turn defaulted the update strategy to 'OnDelete' which was not the desired behaviour.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>