### PR TITLE
fix(hot loop): eliminate hot loop code from reconciler logic

### DIFF
--- a/controller/blockdevice/reconciler.go
+++ b/controller/blockdevice/reconciler.go
@@ -168,7 +168,13 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 		return nil
 	}
 	response.Attachments = append(response.Attachments, op.DesiredBlockDevices...)
-	response.Status = op.Status
+
+	// TODO (@amitkumardas):
+	//
+	// Can't set status as this creates a never ending hot loop
+	// In other words, this updates the watch & reconciliations
+	// of this watch due to other controllers get impacted
+	//response.Status = op.Status
 
 	glog.V(2).Infof(
 		"BlockDevice(s) were associated with Storage %s %s successfully: %s",

--- a/controller/cstorclusterconfig/reconciler.go
+++ b/controller/cstorclusterconfig/reconciler.go
@@ -203,6 +203,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 	// add updated CStorClusterConfig & CStorClusterConfigPlan to response
 	response.Attachments = append(response.Attachments, op.CStorClusterConfig)
 	response.Attachments = append(response.Attachments, op.CStorClusterPlan)
+
 	glog.V(2).Infof(
 		"CStorClusterConfig %s %s reconciled successfully: %s",
 		request.Watch.GetNamespace(), request.Watch.GetName(),

--- a/controller/cstorclusterstorageset/reconciler.go
+++ b/controller/cstorclusterstorageset/reconciler.go
@@ -140,7 +140,13 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 		return nil
 	}
 	response.Attachments = append(response.Attachments, op.DesiredStorages...)
-	response.Status = op.Status
+
+	// TODO (@amitkumardas):
+	//
+	// Can't set status as this creates a never ending hot loop
+	// In other words, this updates the watch & reconciliations
+	// of this watch due to other controllers get impacted
+	//response.Status = op.Status
 
 	glog.V(2).Infof(
 		"CStorClusterStorageSet %s %s reconciled successfully: %s",

--- a/controller/cstorpoolcluster/reconciler.go
+++ b/controller/cstorpoolcluster/reconciler.go
@@ -200,7 +200,13 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 		// not ready to create CStorPoolCluster
 		response.SkipReconcile = true
 	}
-	response.Status = op.Status
+
+	// TODO (@amitkumardas):
+	//
+	// Can't set status as this creates a never ending hot loop
+	// In other words, this updates the watch & reconciliations
+	// of this watch due to other controllers get impacted
+	//response.Status = op.Status
 
 	glog.V(3).Infof(
 		"CStorPoolCluster applied successfully for CStorClusterPlan %s %s: %s",


### PR DESCRIPTION
This commit eliminates all the hot loop code paths from reconciler logic. Current logic was setting status conditions against the watched resource of a controller. However, same watch was used by
multiple controllers which led to a scenario of failed updates experienced at one reconciler as this watch was already updated during this reconcile period by some other reconciler.

The logic of setting status seemed to create this hot loop path. They have been commented as of now. We need to come up with a better plan to manage status & their conditions.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>