### PR TITLE
fix(empty): fix sending empty CStorClusterStorageSet

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,8 +1,14 @@
 ### Design v0.2.0
 #### TODO
 - TODO - 0
-    - metacontroller configs
-        - each config should have unique names
+    - Need to have a CStorClusterDefault CR & corresponding reconciler
+        - Its job will be to set defaults to CStorClusterConfig
+        - Then set the SetDefaultsCompleted condition
+        - This condition will be looked up by the reconciler that creates
+            CStorClusterPlan
+        - This will eliminate the current hot loop path experienced by 
+            CStorClusterConfig reconciler that sets the defaults.
+    - Create EVENTs against the watch instance in case of errors at reconciler
     - deterministic names
         - CStorClusterStorageSet(s)
             - make use of the node that is set in its spec

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -11,7 +11,9 @@ spec:
   attachments:
   - apiVersion: dao.mayadata.io/v1alpha1
     resource: cstorclusterplans
-  - apiVersion: dao.mayadata.io/v1alpha1
+    updateStrategy:
+      method: InPlace
+    - apiVersion: dao.mayadata.io/v1alpha1
     resource: cstorclusterconfigs
     updateStrategy:
       method: InPlace


### PR DESCRIPTION
This commit will fix sending of empty CStorClusterStorageSet from reconciler.

In addition, various TODO items have been added w.r.t refactoring of some reconcilers to eliminate hot loop paths. The suggested plan will be to have a dedicated Defaulting reconciler that sets the defaults against CStorClusterConfig instance.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>