### PR TITLE
fix(nil kind): add the right way to set Kind and APIVersion

### DIFF
--- a/controller/cstorclusterplan/reconciler.go
+++ b/controller/cstorclusterplan/reconciler.go
@@ -393,8 +393,6 @@ func (p *StorageSetsPlanner) create(config *types.CStorClusterConfig) []*unstruc
 		storageSet := &unstructured.Unstructured{}
 		storageSet.SetUnstructuredContent(map[string]interface{}{
 			"metadata": map[string]interface{}{
-				"apiVersion":   types.APIVersionDAOMayaDataV1Alpha1,
-				"kind":         types.KindCStorClusterStorageSet,
 				"generateName": "ccplan-", // ccplan -> CStorClusterPlan
 				"namespace":    p.ClusterPlan.GetNamespace(),
 				"annotations": map[string]interface{}{
@@ -416,6 +414,10 @@ func (p *StorageSetsPlanner) create(config *types.CStorClusterConfig) []*unstruc
 				},
 			},
 		})
+		// below is the right way to set APIVersion & Kind
+		storageSet.SetAPIVersion(string(types.APIVersionDAOMayaDataV1Alpha1))
+		storageSet.SetKind(string(types.KindCStorClusterStorageSet))
+		// add the built up unstruct instance
 		storageSets = append(storageSets, storageSet)
 	}
 	return storageSets

--- a/controller/cstorclusterstorageset/reconciler.go
+++ b/controller/cstorclusterstorageset/reconciler.go
@@ -282,8 +282,6 @@ func (p *StoragePlanner) create(count int64) []*unstructured.Unstructured {
 		new := &unstructured.Unstructured{}
 		new.SetUnstructuredContent(map[string]interface{}{
 			"metadata": map[string]interface{}{
-				"apiVersion":   string(types.APIVersionDAOMayaDataV1Alpha1),
-				"kind":         string(types.KindStorage),
 				"generateName": "ccsset-", // ccsset -> CStorClusterStorageSet
 				"namespace":    p.DesiredNamespace,
 				"annotations": map[string]interface{}{
@@ -295,6 +293,10 @@ func (p *StoragePlanner) create(count int64) []*unstructured.Unstructured {
 				"nodeName": p.DesiredNodeName,
 			},
 		})
+		// below is the right way to create APIVersion & Kind
+		new.SetAPIVersion(string(types.APIVersionDAOMayaDataV1Alpha1))
+		new.SetKind(string(types.KindStorage))
+		// add the newly built unstruct instance to the list
 		desiredStorages = append(desiredStorages, new)
 	}
 	return desiredStorages

--- a/controller/cstorpoolcluster/reconciler.go
+++ b/controller/cstorpoolcluster/reconciler.go
@@ -558,10 +558,8 @@ func (p *Planner) Plan() (*unstructured.Unstructured, error) {
 	desired := &unstructured.Unstructured{}
 	desired.SetUnstructuredContent(map[string]interface{}{
 		"metadata": map[string]interface{}{
-			"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
-			"kind":       string(types.KindCStorPoolCluster),
-			"name":       p.CStorClusterPlan.GetName(),
-			"namespace":  p.CStorClusterPlan.GetNamespace(),
+			"name":      p.CStorClusterPlan.GetName(),
+			"namespace": p.CStorClusterPlan.GetNamespace(),
 			"annotations": map[string]interface{}{
 				string(types.AnnKeyCStorClusterPlanUID):   p.CStorClusterPlan.GetUID(),
 				string(types.AnnKeyCStorClusterConfigUID): p.ObservedClusterConfig.GetUID(),
@@ -571,5 +569,8 @@ func (p *Planner) Plan() (*unstructured.Unstructured, error) {
 			"pools": p.buildDesiredPools(),
 		},
 	})
+	// below is the right way to set APIVersion & Kind
+	desired.SetAPIVersion(string(types.APIVersionOpenEBSV1Alpha1))
+	desired.SetKind(string(types.KindCStorPoolCluster))
 	return desired, nil
 }


### PR DESCRIPTION
This commit provides the right way to set Kind & APIVersion in unstructured instances. This should fix sending of nil kind and nil apiversion in hook responses.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>