### PR TITLE
fix(annotations): use right methods to set annotations

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -36,6 +36,8 @@ spec:
   attachments:
   - apiVersion: dao.mayadata.io/v1alpha1
     resource: cstorclusterstoragesets
+    updateStrategy:
+      method: InPlace
   - apiVersion: dao.mayadata.io/v1alpha1
     resource: cstorclusterconfigs
   hooks:
@@ -55,6 +57,8 @@ spec:
   attachments:
   - apiVersion: dao.mayadata.io/v1alpha1
     resource: storages
+    updateStrategy:
+      method: InPlace
   hooks:
     sync:
       inline:
@@ -96,6 +100,8 @@ spec:
   attachments:
   - apiVersion: openebs.io/v1alpha1
     resource: cstorpoolclusters
+    updateStrategy:
+      method: InPlace
   - apiVersion: openebs.io/v1alpha1
     resource: blockdevices
   - apiVersion: dao.mayadata.io/v1alpha1

--- a/controller/cstorclusterconfig/reconciler.go
+++ b/controller/cstorclusterconfig/reconciler.go
@@ -356,15 +356,10 @@ func (r *Reconciler) syncClusterPlan() error {
 		// name & namespace are same as CStorClusterConfig
 		r.CStorClusterPlan.SetName(r.CStorClusterConfig.GetName())
 		r.CStorClusterPlan.SetNamespace(r.CStorClusterConfig.GetNamespace())
-		// set CStorClusterConfig UID as an annotation for easy
-		// mapping at later stages of the workflow
-		r.CStorClusterPlan.SetAnnotations(
-			k8s.MergeToAnnotations(
-				types.AnnKeyCStorClusterConfigUID,
-				string(r.CStorClusterConfig.GetUID()),
-				r.CStorClusterPlan.GetAnnotations(),
-			),
-		)
+		// create annotations with CStorClusterConfig UID
+		r.CStorClusterPlan.SetAnnotations(map[string]string{
+			types.AnnKeyCStorClusterConfigUID: string(r.CStorClusterConfig.GetUID()),
+		})
 	}
 
 	// Plan should be invoked only after CStorClusterConfig is

--- a/controller/cstorclusterplan/reconciler.go
+++ b/controller/cstorclusterplan/reconciler.go
@@ -395,9 +395,6 @@ func (p *StorageSetsPlanner) create(config *types.CStorClusterConfig) []*unstruc
 			"metadata": map[string]interface{}{
 				"generateName": "ccplan-", // ccplan -> CStorClusterPlan
 				"namespace":    p.ClusterPlan.GetNamespace(),
-				"annotations": map[string]interface{}{
-					string(types.AnnKeyCStorClusterPlanUID): p.ClusterPlan.GetUID(),
-				},
 			},
 			"spec": map[string]interface{}{
 				"node": map[string]interface{}{
@@ -413,6 +410,10 @@ func (p *StorageSetsPlanner) create(config *types.CStorClusterConfig) []*unstruc
 					"storageClassName": config.Spec.DiskConfig.ExternalProvisioner.StorageClassName,
 				},
 			},
+		})
+		// create annotations with CStorClusterPlan UID
+		storageSet.SetAnnotations(map[string]string{
+			types.AnnKeyCStorClusterPlanUID: string(p.ClusterPlan.GetUID()),
 		})
 		// below is the right way to set APIVersion & Kind
 		storageSet.SetAPIVersion(string(types.APIVersionDAOMayaDataV1Alpha1))

--- a/controller/cstorclusterstorageset/reconciler.go
+++ b/controller/cstorclusterstorageset/reconciler.go
@@ -272,9 +272,11 @@ func (p *StoragePlanner) Plan() ([]*unstructured.Unstructured, error) {
 	return finalStorages, nil
 }
 
-// create will create the Storage(s) specifications which when
-// applied should achieve the desired state. It creates given
-// count number of Storage specifications.
+// create will create the **Storage(s)** instances to achieve
+// the desired state.
+//
+// NOTE:
+//	It creates Storage instances based on the given count.
 func (p *StoragePlanner) create(count int64) []*unstructured.Unstructured {
 	var desiredStorages []*unstructured.Unstructured
 	var i int64
@@ -284,14 +286,15 @@ func (p *StoragePlanner) create(count int64) []*unstructured.Unstructured {
 			"metadata": map[string]interface{}{
 				"generateName": "ccsset-", // ccsset -> CStorClusterStorageSet
 				"namespace":    p.DesiredNamespace,
-				"annotations": map[string]interface{}{
-					string(types.AnnKeyCStorClusterStorageSetUID): p.StorageSetUID,
-				},
 			},
 			"spec": map[string]interface{}{
 				"capacity": p.DesiredCapacity,
 				"nodeName": p.DesiredNodeName,
 			},
+		})
+		// create annotations with CStorClusterStorageSet UID
+		new.SetAnnotations(map[string]string{
+			types.AnnKeyCStorClusterStorageSetUID: string(p.StorageSetUID),
 		})
 		// below is the right way to create APIVersion & Kind
 		new.SetAPIVersion(string(types.APIVersionDAOMayaDataV1Alpha1))

--- a/controller/cstorpoolcluster/reconciler.go
+++ b/controller/cstorpoolcluster/reconciler.go
@@ -560,14 +560,15 @@ func (p *Planner) Plan() (*unstructured.Unstructured, error) {
 		"metadata": map[string]interface{}{
 			"name":      p.CStorClusterPlan.GetName(),
 			"namespace": p.CStorClusterPlan.GetNamespace(),
-			"annotations": map[string]interface{}{
-				string(types.AnnKeyCStorClusterPlanUID):   p.CStorClusterPlan.GetUID(),
-				string(types.AnnKeyCStorClusterConfigUID): p.ObservedClusterConfig.GetUID(),
-			},
 		},
 		"spec": map[string]interface{}{
 			"pools": p.buildDesiredPools(),
 		},
+	})
+	// create annotations with CStorClusterPlan UID & CStorClusterConfig UID
+	desired.SetAnnotations(map[string]string{
+		types.AnnKeyCStorClusterPlanUID:   string(p.CStorClusterPlan.GetUID()),
+		types.AnnKeyCStorClusterConfigUID: string(p.ObservedClusterConfig.GetUID()),
 	})
 	// below is the right way to set APIVersion & Kind
 	desired.SetAPIVersion(string(types.APIVersionOpenEBSV1Alpha1))


### PR DESCRIPTION
This commit should fix missing annotations from the custom resources. This logic has used unstructured's own method to set annotations.

In addition, there are changes to config file that allows InPlace updates to resources that form the desired state.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>