### PR TITLE
fix(panic): use resource.Quanity in string format

### DIFF
--- a/controller/cstorclusterstorageset/reconciler.go
+++ b/controller/cstorclusterstorageset/reconciler.go
@@ -312,7 +312,7 @@ func (p *StoragePlanner) update(storage *unstructured.Unstructured) error {
 	err := unstructured.SetNestedMap(
 		storage.UnstructuredContent(),
 		map[string]interface{}{
-			"capacity": p.DesiredCapacity,
+			"capacity": p.DesiredCapacity.String(),
 			"nodeName": p.DesiredNodeName,
 		},
 		"spec",


### PR DESCRIPTION
This change adds the missing reconciliation w.r.t disk details against the CStorClusterStorageSet resources. In addition this commits uses of resource.Quantity in string format to avoid panic as seen below:

```
E1218 06:27:23.621706       1 runtime.go:78] Observed a panic:
&errors.errorString{s:"cannot deep copy resource.Quantity"}
(cannot deep copy resource.Quantity)
goroutine 288 [running]:

k8s.io/apimachinery/pkg/util/runtime.logPanic(0x12d0a80, 0xc00024db00)
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191006235458-f9f2f3f8ab02
/pkg/util/runtime/runtime.go:74 +0xa3

k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191006235458-f9f2f3f8ab02
/pkg/util/runtime/runtime.go:48 +0x82

panic(0x12d0a80, 0xc00024db00)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191006235458-f9f2f3f8ab02
/pkg/runtime/converter.go:474 +0x572

k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191006235458-f9f2f3f8ab02
/pkg/runtime/converter.go:458 +0x149

k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.SetNestedField
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191006235458-f9f2f3f8ab02
/pkg/apis/meta/v1/unstructured/helpers.go:209 +0x39

k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.SetNestedMap(...)
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191006235458-f9f2f3f8ab02
/pkg/apis/meta/v1/unstructured/helpers.go:261
```

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>