### PR TITLE
fix(panic): use map[string]interface{} for all unstructured fields

### DIFF
--- a/controller/cstorclusterplan/reconciler.go
+++ b/controller/cstorclusterplan/reconciler.go
@@ -381,7 +381,7 @@ func (p *StorageSetsPlanner) updateDiskOnly(config *types.CStorClusterConfig) ([
 		// NOTE:
 		//	Disk details might not have changed. However we shall
 		// still set them to keep the logic idempotent.
-		disk := map[string]string{
+		disk := map[string]interface{}{
 			"capacity": config.Spec.DiskConfig.MinCapacity.String(),
 			"count":    config.Spec.DiskConfig.MinCount.String(),
 		}
@@ -480,7 +480,7 @@ func (p *StorageSetsPlanner) update(config *types.CStorClusterConfig) ([]*unstru
 		)
 
 		// set new node details
-		node := map[string]string{
+		node := map[string]interface{}{
 			"name": p.PlannedNodeNames[newNodeUID],
 			"uid":  newNodeUID,
 		}
@@ -500,7 +500,7 @@ func (p *StorageSetsPlanner) update(config *types.CStorClusterConfig) ([]*unstru
 		// NOTE:
 		//	Disk details might not have changed. However we shall
 		// still set them to keep the logic idempotent.
-		disk := map[string]string{
+		disk := map[string]interface{}{
 			"capacity": config.Spec.DiskConfig.MinCapacity.String(),
 			"count":    config.Spec.DiskConfig.MinCount.String(),
 		}


### PR DESCRIPTION
This commit should fixe following panic:

```
E1218 08:05:03.754529       1 runtime.go:78] Observed a panic:
&errors.errorString{s:"cannot deep copy map[string]string"}
(cannot deep copy map[string]string)
goroutine 271 [running]:

k8s.io/apimachinery/pkg/util/runtime.logPanic
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191006235458-f9f2f3f8ab02
/pkg/util/runtime/runtime.go:74 +0xa3

k8s.io/apimachinery/pkg/util/runtime.HandleCrash
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191006235458-f9f2f3f8ab02
/pkg/util/runtime/runtime.go:48 +0x82

panic
	/usr/local/go/src/runtime/panic.go:522 +0x1b5

k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191006235458-f9f2f3f8ab02
/pkg/runtime/converter.go:474 +0x572

k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.SetNestedField
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191006235458-f9f2f3f8ab02
/pkg/apis/meta/v1/unstructured/helpers.go:209 +0x39
```

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>