### PR TITLE
fix(annotations): set storage provisioner annotations

### DIFF
--- a/TODO
+++ b/TODO
@@ -22,6 +22,9 @@
         - Remove / Scale Down should be done to young disks
             - current logic removes young nodes.
             - however, young nodes may attach old disks i.e. bigger data
+    - Finish the TODO markers in the code
+    - Create/Update construction should be same & hence should come from one func
+        - This is very important to make the code adhere to being idempotent
 - TODO - 1
     - update storage provisioner codebase
     - change ddp to dao

--- a/types/annotations.go
+++ b/types/annotations.go
@@ -17,6 +17,9 @@ limitations under the License.
 package types
 
 const (
+	// TODO (@amitkumardas):
+	//	Change this to cstorpoolauto.dao.mayadata.io
+
 	// AnnotationNamespace is the common namespace used across all
 	// the annotations supported in this project
 	AnnotationNamespace string = "dao.mayadata.io"
@@ -35,4 +38,16 @@ const (
 
 	// AnnKeyStorageUID is the annotation that refers to Storage UID
 	AnnKeyStorageUID string = AnnotationNamespace + "/storage-uid"
+
+	// StorageProvisionerAnnotationNamespace is the common namespace
+	// used across all the annotations supported in storage-provisioner project
+	StorageProvisionerAnnotationNamespace string = "storageprovisioner.dao.mayadata.io"
+
+	// AnnKeyStorageProvisionerCSIAttacherName is the annotationn that refers
+	// to CSIAttacherName
+	AnnKeyStorageProvisionerCSIAttacherName string = StorageProvisionerAnnotationNamespace + "/csi-attacher-name"
+
+	// AnnKeyStorageProvisionerStorageClassName is the annotation that refers
+	// to StorageClassName
+	AnnKeyStorageProvisionerStorageClassName string = StorageProvisionerAnnotationNamespace + "/storageclass-name"
 )


### PR DESCRIPTION
This commit sets storage provisioner based annotations to let storage provisioner to kick in.

Following annotations are used:
```
storageprovisioner.dao.mayadata.io/csi-attacher-name
storageprovisioner.dao.mayadata.io/storageclass-name
```

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>