### PR TITLE
fix(annotations): sync only required annotations

### DIFF
--- a/util/string/string.go
+++ b/util/string/string.go
@@ -21,6 +21,11 @@ import "strings"
 // List is a representation of list of strings
 type List []string
 
+// String implements Stringer interface
+func (l List) String() string {
+	return strings.Join(l, ", ")
+}
+
 // ContainsExact returns true if given string is exact
 // match with one if the items in the list
 func (l List) ContainsExact(given string) bool {


### PR DESCRIPTION
This commit should fix the case where blockdevices were filled up with old & new annotations. With this change the reconcile code needs to bother about the desired annotations & leave the rest to metac that will in turn merge these desired annotations with old annotations if any.

NOTE: This merge logic holds good for any resource specifications as well.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>