### PR TITLE
fix(annotations): move to labels from annotations

### DIFF
--- a/controller/blockdevice/reconciler.go
+++ b/controller/blockdevice/reconciler.go
@@ -461,15 +461,21 @@ func (p *StorageToBlockDeviceAssociator) annotateBlockDevicesIfUnclaimed(
 		}
 		// add CStorClusterStorageSet UID to device's
 		// existing annotations
-		newAnns := k8s.MergeToAnnotations(
+		//
+		// TODO (@amitkumardas):
+		//	We are using labels since there might be a bug
+		// in metac to merge annotations. Use of labels is a
+		// workaround that needs to be changed to annotations
+		// once metac fixes this bug.
+		newLbls := k8s.MergeToAnnotations(
 			types.AnnKeyCStorClusterStorageSetUID, string(p.StorageSet.GetUID()),
-			device.GetAnnotations(),
+			device.GetLabels(),
 		)
 		// add CStorClusterPlan UID to device's
 		// existing annotations
-		newAnns = k8s.MergeToAnnotations(
+		newLbls = k8s.MergeToAnnotations(
 			types.AnnKeyCStorClusterPlanUID, cstorClusterPlanUID,
-			newAnns,
+			newLbls,
 		)
 
 		new := &unstructured.Unstructured{}
@@ -477,10 +483,12 @@ func (p *StorageToBlockDeviceAssociator) annotateBlockDevicesIfUnclaimed(
 		new.SetKind(device.GetKind())
 		new.SetNamespace(device.GetNamespace())
 		new.SetName(device.GetName())
-		new.SetAnnotations(newAnns)
+		// TODO (@amitkumardas):
+		//	Read above note on why labels vs. annotations
+		new.SetLabels(newLbls)
 
 		glog.V(2).Infof(
-			"BlockDevice %s %s associated / annotated successfully: CStorClusterStorageSet %s: CStorClusterPlan %s",
+			"BlockDevice %s %s associated successfully: CStorClusterStorageSet %s: CStorClusterPlan %s",
 			device.GetNamespace(),
 			device.GetName(),
 			p.StorageSet.GetUID(),

--- a/controller/cstorpoolcluster/reconciler.go
+++ b/controller/cstorpoolcluster/reconciler.go
@@ -138,7 +138,12 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 			// verify further if this belongs to the current watch
 			// i.e. CStorClusterPlan
 			uid, _ := k8s.GetAnnotationForKey(
-				attachment.GetAnnotations(), types.AnnKeyCStorClusterPlanUID,
+				// TODO (@amitkumardas):
+				//	We are using labels since there might be a bug
+				// in metac to merge annotations. Use of labels is a
+				// workaround that needs to be changed to annotations
+				// once metac fixes this bug.
+				attachment.GetLabels(), types.AnnKeyCStorClusterPlanUID,
 			)
 			if string(request.Watch.GetUID()) == uid {
 				// this is one of the desired BlockDevice(s)
@@ -477,7 +482,12 @@ func (p *Planner) initStorageSetToBlockDevices() error {
 	p.storageSetToBlockDevices = map[string][]string{}
 	for _, device := range p.ObservedBlockDevices {
 		sSetUID, found := k8s.GetAnnotationForKey(
-			device.GetAnnotations(), types.AnnKeyCStorClusterStorageSetUID,
+			// TODO (@amitkumardas):
+			//	We are using labels since there might be a bug
+			// in metac to merge annotations. Use of labels is a
+			// workaround that needs to be changed to annotations
+			// once metac fixes this bug.
+			device.GetLabels(), types.AnnKeyCStorClusterStorageSetUID,
 		)
 		if !found || sSetUID == "" {
 			return errors.Errorf(

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -26,7 +26,7 @@ spec:
         args:
         - --logtostderr
         - --run-as-local
-        - -v=4
+        - -v=3
         - --discovery-interval=40s
         - --cache-flush-interval=240s
 ---


### PR DESCRIPTION
This commit is a workaround due to a bug in metac. This modified logic moves away from blockdevice annotations & uses labels in its place.

**_NOTE:_**
Metac is not merging the annotations properly when reconciling a resource to its desired state. This happens in GenericController with updateAny set to true and the resource updateStratgey being
InPlace. In addition, it happens when some annotation is modified in the targeted resource with above update tunables.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>