### PR TITLE
validate(diskcount): validate disk count w.r.t. RAID group

### DIFF
--- a/TODO
+++ b/TODO
@@ -23,9 +23,10 @@
             - current logic removes young nodes.
             - however, young nodes may attach old disks i.e. bigger data
     - Finish the TODO markers in the code
-    - Create/Update construction should be same & hence should come from one func
+    - Create/Update construction should be same **In Progress**
         - This is very important to make the code adhere to being idempotent
     - Check use of runtime.DefaultUnstructuredConverter.FromUnstructured(...)
+    - Use k8s Events to show errors
 - TODO - 1
     - write delete contollers
 - TODO - 2

--- a/controller/cstorclusterconfig/reconciler.go
+++ b/controller/cstorclusterconfig/reconciler.go
@@ -404,6 +404,7 @@ func (r *Reconciler) validateClusterConfigAndSetDefaultsIfNotSet() error {
 		r.setRAIDTypeIfNotSet,
 		r.setMinDiskCountIfNotSet,
 		r.setMinDiskCapacityIfNotSet,
+		r.validateMinDiskCount,
 	}
 	for _, setDefaultFn := range setDefaultFns {
 		err := setDefaultFn()
@@ -517,6 +518,19 @@ func (r *Reconciler) setMinDiskCapacityIfNotSet() error {
 		return nil
 	}
 	r.CStorClusterConfig.Spec.DiskConfig.MinCapacity = DefaultMinDiskCapacity
+	return nil
+}
+
+func (r *Reconciler) validateMinDiskCount() error {
+	diskCount := r.CStorClusterConfig.Spec.DiskConfig.MinCount
+	defaultCount :=
+		RAIDTypeToDefaultMinDiskCount[r.CStorClusterConfig.Spec.PoolConfig.RAIDType]
+
+	if diskCount.Value()%defaultCount != 0 {
+		return errors.Errorf(
+			"Invalid disk count %d: Want multiples of %d", diskCount.Value(), defaultCount,
+		)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This commit validates the disk count per pool instance based on the specified RAID group type.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>