### PR TITLE
fix(ready conds): fix node disk ready conditions

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,5 +1,10 @@
 #### TODO
 - TODO - 0
+    - Eliminate the need to check logs - Make it easy
+        - Store warnings, infos, errors of all controllers in cstorpoolauto
+        - Store them against a CR
+        - Infos or Warnings should be based on verbose level of this CR
+        - Info, warn or error should have context info as well
     - Update go dependency to include latest version of Metac
     - update go version
     - make use of github actions

--- a/controller/cstorpoolcluster/reconciler.go
+++ b/controller/cstorpoolcluster/reconciler.go
@@ -105,7 +105,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 	}
 
 	glog.V(3).Infof(
-		"Will apply CStorPoolCluster for CStorClusterPlan %s %s:",
+		"Will apply CStorPoolCluster for CStorClusterPlan %q / %q:",
 		request.Watch.GetNamespace(), request.Watch.GetName(),
 	)
 
@@ -214,7 +214,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 	//response.Status = op.Status
 
 	glog.V(3).Infof(
-		"CStorPoolCluster applied successfully for CStorClusterPlan %s %s: %s",
+		"CStorPoolCluster applied successfully for CStorClusterPlan %q / %q: %s",
 		request.Watch.GetNamespace(), request.Watch.GetName(),
 		metac.GetDetailsFromResponse(response),
 	)
@@ -362,14 +362,14 @@ func (p *Planner) isReadyByNodeCount() bool {
 	desiredNodeCount := len(p.CStorClusterPlan.Spec.Nodes)
 	if desiredNodeCount == 0 {
 		glog.V(3).Infof(
-			"Will skip applying CStorPoolCluster %s %s: 0 desired nodes",
+			"Skip CStorPoolCluster %q / %q: 0 desired nodes",
 			p.CStorClusterPlan.GetNamespace(), p.CStorClusterPlan.GetName(),
 		)
 		return false
 	}
 	if desiredNodeCount != len(p.ObservedStorageSets) {
 		glog.V(3).Infof(
-			"Will skip applying CStorPoolCluster %s %s: Desired Node(s) %d: Observed StorageSet(s) %d",
+			"Skip CStorPoolCluster %q / %q: Want Node(s) %d: Got Nodes i.e. StorageSet(s) %d",
 			p.CStorClusterPlan.GetNamespace(),
 			p.CStorClusterPlan.GetName(),
 			desiredNodeCount,
@@ -393,9 +393,9 @@ func (p *Planner) isReadyByNodeCount() bool {
 func (p *Planner) isReadyByNodeDiskCount() bool {
 	for storageSetUID, desiredDiskCount := range p.storageSetToDesiredDiskCount {
 		observedDeviceCount := int64(len(p.storageSetToBlockDevices[storageSetUID]))
-		if desiredDiskCount.CmpInt64(observedDeviceCount) != 0 {
+		if desiredDiskCount.CmpInt64(observedDeviceCount) > 0 {
 			glog.V(3).Infof(
-				"Will skip applying CStorPoolCluster %s %s: Desired Disk(s) %s: Observed Disks(s) %d: StorageSet UID %s",
+				"Skip CStorPoolCluster %q / %q: Want Disk(s) %s: Got Disks(s) %d: StorageSet UID %q",
 				p.CStorClusterPlan.GetNamespace(),
 				p.CStorClusterPlan.GetName(),
 				desiredDiskCount.String(),

--- a/controller/cstorpoolcluster/reconciler_test.go
+++ b/controller/cstorpoolcluster/reconciler_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorpoolcluster
+
+import (
+	"cstorpoolauto/types"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestPlannerIsReadyByNodeCount(t *testing.T) {
+	var tests = map[string]struct {
+		planner *Planner
+		isReady bool
+	}{
+		"node count == observed storageset count": {
+			planner: &Planner{
+				CStorClusterPlan: &types.CStorClusterPlan{
+					Spec: types.CStorClusterPlanSpec{
+						Nodes: []types.CStorClusterPlanNode{
+							types.CStorClusterPlanNode{},
+							types.CStorClusterPlanNode{},
+						},
+					},
+				},
+				ObservedStorageSets: []*unstructured.Unstructured{
+					&unstructured.Unstructured{},
+					&unstructured.Unstructured{},
+				},
+			},
+			isReady: true,
+		},
+		"node count < observed storageset count": {
+			planner: &Planner{
+				CStorClusterPlan: &types.CStorClusterPlan{
+					Spec: types.CStorClusterPlanSpec{
+						Nodes: []types.CStorClusterPlanNode{
+							types.CStorClusterPlanNode{},
+						},
+					},
+				},
+				ObservedStorageSets: []*unstructured.Unstructured{
+					&unstructured.Unstructured{},
+					&unstructured.Unstructured{},
+				},
+			},
+			isReady: false,
+		},
+		"node count > observed storageset count": {
+			planner: &Planner{
+				CStorClusterPlan: &types.CStorClusterPlan{
+					Spec: types.CStorClusterPlanSpec{
+						Nodes: []types.CStorClusterPlanNode{
+							types.CStorClusterPlanNode{},
+							types.CStorClusterPlanNode{},
+						},
+					},
+				},
+				ObservedStorageSets: []*unstructured.Unstructured{
+					&unstructured.Unstructured{},
+				},
+			},
+			isReady: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			got := mock.planner.isReadyByNodeCount()
+			if got != mock.isReady {
+				t.Fatalf("Want %t got %t", mock.isReady, got)
+			}
+		})
+	}
+}
+
+func TestPlannerIsReadyByNodeDiskCount(t *testing.T) {
+	mockloginfo := &types.CStorClusterPlan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+	var tests = map[string]struct {
+		planner *Planner
+		isReady bool
+	}{
+		"desired disk count == observed disk count": {
+			planner: &Planner{
+				storageSetToDesiredDiskCount: map[string]resource.Quantity{
+					"101": resource.MustParse("1"),
+				},
+				storageSetToBlockDevices: map[string][]string{
+					"101": []string{"bd1"},
+				},
+			},
+			isReady: true,
+		},
+		"desired disk count > observed disk count": {
+			planner: &Planner{
+				// TODO (@amitkumardas):
+				// 	Use log as a field in Planner
+				CStorClusterPlan: mockloginfo,
+				storageSetToDesiredDiskCount: map[string]resource.Quantity{
+					"101": resource.MustParse("2"),
+				},
+				storageSetToBlockDevices: map[string][]string{
+					"101": []string{"bd1"},
+				},
+			},
+			isReady: false,
+		},
+		"desired disk count < observed disk count": {
+			planner: &Planner{
+				storageSetToDesiredDiskCount: map[string]resource.Quantity{
+					"101": resource.MustParse("2"),
+				},
+				storageSetToBlockDevices: map[string][]string{
+					"101": []string{"bd1", "bd2", "bd3"},
+				},
+			},
+			isReady: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			got := mock.planner.isReadyByNodeDiskCount()
+			if got != mock.isReady {
+				t.Fatalf("Want %t got %t", mock.isReady, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit fixes the condition that skips reconciliation when desired disk count is less than observed disk count. Logic now allows reconciliation when desired disk count >= observed disk count. In addition, several Unit Tests are added to verify this behaviour.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>