### PR TITLE
fix(blockdevice): filter blockdevices that are Active

### DIFF
--- a/types/status.go
+++ b/types/status.go
@@ -76,7 +76,7 @@ const (
 	StatusPhaseError StatusPhase = "Error"
 )
 
-// DeviceClaimState defines the observed state of BlockDevice
+// DeviceClaimState defines the observed claim state of BlockDevice
 type DeviceClaimState string
 
 const (
@@ -84,6 +84,21 @@ const (
 	// not bound to any BDC, all cleanup jobs have been completed
 	// and is available for claiming.
 	BlockDeviceUnclaimed DeviceClaimState = "Unclaimed"
+
+	// BlockDeviceClaimed represents that the block device is
+	// bound to any BDC currently
+	BlockDeviceClaimed DeviceClaimState = "Claimed"
+)
+
+// DeviceState defines the observed state of BlockDevice
+type DeviceState string
+
+const (
+	// BlockDeviceActive represents a Active BlockDevice
+	BlockDeviceActive DeviceState = "Active"
+
+	// BlockDeviceInactive represents an Inactive BlockDevice
+	BlockDeviceInactive DeviceState = "Inactive"
 )
 
 // now returns the current time in following format


### PR DESCRIPTION
This commit fixes the filtering logic of block devices in the controller that deals with applying CStorPoolCluster. It now filters the devices if claim state is either Claimed or Unclaimed. It further filters the devices which are in Active state.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>