### PR TITLE
fix(status): remove error updates against status

### DIFF
--- a/TODO
+++ b/TODO
@@ -37,16 +37,16 @@
     - add status.conditions to storage API
     - set Storage's UID against PVC's annotations
 - TODO - 3
-    - refactor clusterconfig reconciler
+    - refactor clusterconfig reconciler - In Progress
     - manage status/conditions of clusterconfig
     - refactor reconcile logic to:
         - Defaulter,
         - CStorClusterPlanner & 
         - NodePlanner
 - TODO - 4
-    - test scripts / demos
+    - Demos - Done
 - TODO - 5
-    - Unit Tests for cstorpoolauto
+    - Unit Tests - In Progress
 - TODO - 6
     - refactor storage provisioner to use metac
 - TODO - 7

--- a/controller/cstorclusterconfig/node.go
+++ b/controller/cstorclusterconfig/node.go
@@ -232,6 +232,7 @@ type NodePlanner struct {
 	allowedNodes []*unstructured.Unstructured
 
 	// functions that make it easy to mock this structure
+	planFn                func(conf NodePlannerConfig) ([]types.CStorClusterPlanNode, error)
 	getAllNodeCountFn     func() int64
 	getAllowedNodeCountFn func() (int64, error)
 }
@@ -323,6 +324,15 @@ func (s *NodePlanner) GetAllowedNodeCount() (int64, error) {
 // Plan runs through node planner config to determine
 // the latest desired nodes that should form the CStorPoolCluster
 func (s *NodePlanner) Plan(conf NodePlannerConfig) ([]types.CStorClusterPlanNode, error) {
+	if s.planFn != nil {
+		return s.planFn(conf)
+	}
+	return s.plan(conf)
+}
+
+// plan runs through node planner config to determine
+// the latest desired nodes that should form the CStorPoolCluster
+func (s *NodePlanner) plan(conf NodePlannerConfig) ([]types.CStorClusterPlanNode, error) {
 	allowedNodes, err := s.GetAllowedNodesOrCached()
 	if err != nil {
 		return nil, err

--- a/k8s/util.go
+++ b/k8s/util.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // GetNestedSlice returns the slice found at given field path
@@ -216,4 +217,22 @@ func GetAnnotationForKey(given map[string]string, key string) (string, bool) {
 	}
 	val, found := given[key]
 	return val, found
+}
+
+// UnstructToTyped transforms the provided unstruct instance
+// to target type
+func UnstructToTyped(src *unstructured.Unstructured, target interface{}) error {
+	if src == nil || src.UnstructuredContent() == nil {
+		return errors.Errorf(
+			"Can't transform unstruct to typed: Nil unstruct content",
+		)
+	}
+	if target == nil {
+		return errors.Errorf(
+			"Can't transform unstruct to typed: Nil target",
+		)
+	}
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(
+		src.UnstructuredContent(), target,
+	)
 }

--- a/k8s/util_test.go
+++ b/k8s/util_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"cstorpoolauto/types"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestUnstructToTyped(t *testing.T) {
+	var tests = map[string]struct {
+		src    *unstructured.Unstructured
+		target interface{}
+		isErr  bool
+	}{
+		"src = nil && target = nil": {
+			src:    nil,
+			target: nil,
+			isErr:  true,
+		},
+		"src = empty && target = nil": {
+			src:    &unstructured.Unstructured{},
+			target: nil,
+			isErr:  true,
+		},
+		"src = empty && target = non pointer": {
+			src:    &unstructured.Unstructured{},
+			target: types.CStorClusterConfig{},
+			isErr:  true,
+		},
+		"src = empty && target = unstruct pointer": {
+			src:    &unstructured.Unstructured{},
+			target: &unstructured.Unstructured{},
+			isErr:  true,
+		},
+		"src = valid && target = unstruct pointer": {
+			src: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "ABC",
+				},
+			},
+			target: &unstructured.Unstructured{},
+			isErr:  false,
+		},
+		"src = valid && target = cstorclusterconfig pointer": {
+			src: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "CStorClusterConfig",
+				},
+			},
+			target: &types.CStorClusterConfig{},
+			isErr:  false,
+		},
+		"src = invalid && target = cstorclusterconfig pointer": {
+			src: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "CStorClusterConfig",
+					"spec": map[string]interface{}{
+						"junk": map[string]interface{}{
+							"hi": "hello",
+						},
+					},
+				},
+			},
+			target: &types.CStorClusterConfig{},
+			isErr:  false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			got := UnstructToTyped(mock.src, mock.target)
+			if mock.isErr && got == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && got != nil {
+				t.Fatalf("Expected no error got [%+v]", got)
+			}
+		})
+	}
+}

--- a/types/cstorclusterplan.go
+++ b/types/cstorclusterplan.go
@@ -79,3 +79,18 @@ type CStorClusterPlanStatusCondition struct {
 	Reason           string         `json:"reason,omitempty"`
 	LastObservedTime string         `json:"lastObservedTime"`
 }
+
+// MakeNodeSlice returns a slice of unstructured maps from
+// the given slice of CStorClusterPlanNode
+func MakeNodeSlice(given []CStorClusterPlanNode) []map[string]interface{} {
+	var nodeSlice []map[string]interface{}
+	for _, node := range given {
+		nodeSlice = append(nodeSlice,
+			map[string]interface{}{
+				"name": node.Name,
+				"uid":  node.UID,
+			},
+		)
+	}
+	return nodeSlice
+}

--- a/types/cstorclusterplan_test.go
+++ b/types/cstorclusterplan_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestMakeNodeSlice(t *testing.T) {
+	var tests = map[string]struct {
+		nodes       []CStorClusterPlanNode
+		expectCount int
+	}{
+		"Nodes = nil": {
+			expectCount: 0,
+		},
+		"Node count = 1 && valid nodes": {
+			nodes: []CStorClusterPlanNode{
+				CStorClusterPlanNode{
+					Name: "node1",
+					UID:  types.UID("123"),
+				},
+			},
+			expectCount: 1,
+		},
+		"Node count = 1 && in-valid nodes": {
+			nodes: []CStorClusterPlanNode{
+				CStorClusterPlanNode{
+					Name: "",
+					UID:  types.UID(""),
+				},
+			},
+			expectCount: 1,
+		},
+		"Node count = 2 && valid nodes": {
+			nodes: []CStorClusterPlanNode{
+				CStorClusterPlanNode{
+					Name: "node1",
+					UID:  types.UID("123"),
+				},
+				CStorClusterPlanNode{
+					Name: "node2",
+					UID:  types.UID("123-123"),
+				},
+			},
+			expectCount: 2,
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := MakeNodeSlice(mock.nodes)
+			if len(got) != mock.expectCount {
+				t.Fatalf(
+					"Expected count %d got %d", mock.expectCount, len(got),
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit removes updating error information against status of CStorClusterConfig during reconciliation. This should remove hot loop path experienced due to constant updates to the status.

In addition, there are several unit tests against CStorClusterConfig reconciliation codebase.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>