### PR TITLE
change module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module mayadata.io/cstorpoolauto
+module mayadata-io/cstorpoolauto
 
 go 1.13
 


### PR DESCRIPTION
change module path from `mayadata.io` to `mayadata-io` to fix the import issue.

I am facing this issue while importing it's package
```bash
$ go mod tidy
go: finding github.com/mayadata-io/cstorpoolauto latest
go: downloading github.com/mayadata-io/cstorpoolauto v0.0.0-20200123060608-1b86ac841d3a
go: extracting github.com/mayadata-io/cstorpoolauto v0.0.0-20200123060608-1b86ac841d3a
go: github.com/mayadata-io/openebs-manager imports
	github.com/mayadata-io/cstorpoolauto/controller/blockdevice: github.com/mayadata-io/cstorpoolauto@v0.0.0-20200123060608-1b86ac841d3a: parsing go.mod:
	module declares its path as: mayadata.io/cstorpoolauto
	        but was required as: github.com/mayadata-io/cstorpoolauto
```