### PR TITLE
fix(raidgroups): fix placement of raid group in CStorPoolCluster

### DIFF
--- a/controller/cstorclusterconfig/reconciler.go
+++ b/controller/cstorclusterconfig/reconciler.go
@@ -46,15 +46,6 @@ const (
 // DefaultMinDiskCapacity is the default min disk capacity
 var DefaultMinDiskCapacity resource.Quantity = resource.MustParse("100Gi")
 
-// RAIDTypeToDefaultMinDiskCount maps pool instance's raid type
-// to its default minimum disk count
-var RAIDTypeToDefaultMinDiskCount = map[types.PoolRAIDType]int64{
-	types.PoolRAIDTypeMirror: 2,
-	types.PoolRAIDTypeStripe: 1,
-	types.PoolRAIDTypeRAIDZ:  3,
-	types.PoolRAIDTypeRAIDZ2: 6,
-}
-
 type reconcileErrHandler struct {
 	clusterConfig *unstructured.Unstructured
 	hookResponse  *generic.SyncHookResponse
@@ -136,7 +127,7 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 		}
 		if attachment.GetKind() == string(types.KindCStorClusterPlan) {
 			// verify further if CStorClusterPlan is what we are looking
-			uid, _ := k8s.GetAnnotationForKey(
+			uid, _ := k8s.GetValueForKey(
 				attachment.GetAnnotations(), types.AnnKeyCStorClusterConfigUID,
 			)
 			if string(request.Watch.GetUID()) == uid {
@@ -497,7 +488,7 @@ func (r *Reconciler) setMinDiskCountIfNotSet() error {
 	// This will help in differentiating a value that was not
 	// set vs. a value that was set to 0.
 	r.minDiskCount =
-		RAIDTypeToDefaultMinDiskCount[r.poolRAIDType]
+		types.RAIDTypeToDefaultMinDiskCount[r.poolRAIDType]
 	return nil
 }
 
@@ -540,7 +531,7 @@ func (r *Reconciler) validateMinDiskCount() error {
 			"Invalid min disk count '0'",
 		)
 	}
-	defaultCount := RAIDTypeToDefaultMinDiskCount[r.poolRAIDType]
+	defaultCount := types.RAIDTypeToDefaultMinDiskCount[r.poolRAIDType]
 	if defaultCount == 0 {
 		return errors.Errorf(
 			"Can't eval default disk count: RAID type %q is not set", r.poolRAIDType,

--- a/controller/cstorclusterplan/reconciler.go
+++ b/controller/cstorclusterplan/reconciler.go
@@ -110,13 +110,13 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 	var observedStorageSets []*unstructured.Unstructured
 	var cstorClusterConfig *unstructured.Unstructured
 	var desiredCStorClusterConfigUID string
-	desiredCStorClusterConfigUID, _ = k8s.GetAnnotationForKey(
+	desiredCStorClusterConfigUID, _ = k8s.GetValueForKey(
 		request.Watch.GetAnnotations(), types.AnnKeyCStorClusterConfigUID,
 	)
 	for _, attachment := range request.Attachments.List() {
 		if attachment.GetKind() == string(types.KindCStorClusterStorageSet) {
 			// verify further if CStorClusterStorageSet belongs to current watch
-			uid, _ := k8s.GetAnnotationForKey(
+			uid, _ := k8s.GetValueForKey(
 				attachment.GetAnnotations(), types.AnnKeyCStorClusterPlanUID,
 			)
 			if string(request.Watch.GetUID()) == uid {

--- a/controller/cstorpoolcluster/reconciler_test.go
+++ b/controller/cstorpoolcluster/reconciler_test.go
@@ -17,13 +17,1286 @@ limitations under the License.
 package cstorpoolcluster
 
 import (
-	"mayadata.io/cstorpoolauto/types"
+	"reflect"
 	"testing"
+
+	"mayadata.io/cstorpoolauto/k8s"
+	"mayadata.io/cstorpoolauto/types"
+	stringutil "mayadata.io/cstorpoolauto/util/string"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+func TestPlannerGetDesiredCStorPoolCluster(t *testing.T) {
+	var tests = map[string]struct {
+		observedCStorClusterPlan        *types.CStorClusterPlan
+		observedClusterConfig           *unstructured.Unstructured
+		desiredRAIDType                 string
+		nodeNameToObservedStorageSetUID map[string]string
+		nodeNameToDesiredCSPCDevices    map[string][]string
+		expectCSPC                      *unstructured.Unstructured
+	}{
+		"Mirror : 2x4 : 2 Pools x 4 Disks on each Pool": {
+			observedCStorClusterPlan: &types.CStorClusterPlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mirror-2x4",
+					Namespace: "test-mirror",
+					UID:       "plan-101",
+				},
+			},
+			observedClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"uid": "config-101",
+					},
+				},
+			},
+			desiredRAIDType: string(types.PoolRAIDTypeMirror),
+			nodeNameToObservedStorageSetUID: map[string]string{
+				"node-101": "sset-101",
+				"node-201": "sset-201",
+			},
+			nodeNameToDesiredCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2", "bd-3", "bd-4"},
+				"node-201": []string{"bd-5", "bd-6", "bd-7", "bd-8"},
+			},
+			expectCSPC: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "mirror-2x4",
+						"namespace": "test-mirror",
+						"annotations": map[string]interface{}{
+							string(types.AnnKeyCStorClusterPlanUID):   "plan-101",
+							string(types.AnnKeyCStorClusterConfigUID): "config-101",
+						},
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-101",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-1",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-2",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-3",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-4",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-201",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-5",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-6",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-7",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-8",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"Mirror : 2x2 : 2 Pools x 2 Disks on each Pool": {
+			observedCStorClusterPlan: &types.CStorClusterPlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mirror-2x2",
+					Namespace: "test-mirror",
+					UID:       "plan-101",
+				},
+			},
+			observedClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"uid": "config-101",
+					},
+				},
+			},
+			desiredRAIDType: string(types.PoolRAIDTypeMirror),
+			nodeNameToObservedStorageSetUID: map[string]string{
+				"node-101": "sset-101",
+				"node-201": "sset-201",
+			},
+			nodeNameToDesiredCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2"},
+				"node-201": []string{"bd-3", "bd-4"},
+			},
+			expectCSPC: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "mirror-2x2",
+						"namespace": "test-mirror",
+						"annotations": map[string]interface{}{
+							string(types.AnnKeyCStorClusterPlanUID):   "plan-101",
+							string(types.AnnKeyCStorClusterConfigUID): "config-101",
+						},
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-101",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-1",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-2",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-201",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-3",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-4",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"Stripe: 2x4 : 2 Pools x 4 Disks on each Pool": {
+			observedCStorClusterPlan: &types.CStorClusterPlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stripe-2x4",
+					Namespace: "test-stripe",
+					UID:       "plan-101",
+				},
+			},
+			observedClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"uid": "config-101",
+					},
+				},
+			},
+			desiredRAIDType: string(types.PoolRAIDTypeStripe),
+			nodeNameToObservedStorageSetUID: map[string]string{
+				"node-101": "sset-101",
+				"node-201": "sset-201",
+			},
+			nodeNameToDesiredCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2", "bd-3", "bd-4"},
+				"node-201": []string{"bd-5", "bd-6", "bd-7", "bd-8"},
+			},
+			expectCSPC: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "stripe-2x4",
+						"namespace": "test-stripe",
+						"annotations": map[string]interface{}{
+							string(types.AnnKeyCStorClusterPlanUID):   "plan-101",
+							string(types.AnnKeyCStorClusterConfigUID): "config-101",
+						},
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "stripe",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-101",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-1",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-2",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-3",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-4",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "stripe",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-201",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-5",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-6",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-7",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-8",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"RAIDZ : 2x6 : 2 Pools x 6 Disks on each Pool": {
+			observedCStorClusterPlan: &types.CStorClusterPlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "raidz-2x6",
+					Namespace: "test-raidz",
+					UID:       "plan-101",
+				},
+			},
+			observedClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"uid": "config-101",
+					},
+				},
+			},
+			desiredRAIDType: string(types.PoolRAIDTypeRAIDZ),
+			nodeNameToObservedStorageSetUID: map[string]string{
+				"node-101": "sset-101",
+				"node-201": "sset-201",
+			},
+			nodeNameToDesiredCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2", "bd-3", "bd-4", "bd-5", "bd-6"},
+				"node-201": []string{"bd-7", "bd-8", "bd-9", "bd-10", "bd-11", "bd-12"},
+			},
+			expectCSPC: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "raidz-2x6",
+						"namespace": "test-raidz",
+						"annotations": map[string]interface{}{
+							string(types.AnnKeyCStorClusterPlanUID):   "plan-101",
+							string(types.AnnKeyCStorClusterConfigUID): "config-101",
+						},
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "raidz",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-101",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-1",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-2",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-3",
+											},
+										},
+										"type":         "raidz",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-4",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-5",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-6",
+											},
+										},
+										"type":         "raidz",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "raidz",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-201",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-7",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-8",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-9",
+											},
+										},
+										"type":         "raidz",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-10",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-11",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-12",
+											},
+										},
+										"type":         "raidz",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"RAIDZ2 : 2x6 : 2 Pools x 6 Disks on each Pool": {
+			observedCStorClusterPlan: &types.CStorClusterPlan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "raidz2-2x6",
+					Namespace: "test-raidz2",
+					UID:       "plan-101",
+				},
+			},
+			observedClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"uid": "config-101",
+					},
+				},
+			},
+			desiredRAIDType: string(types.PoolRAIDTypeRAIDZ2),
+			nodeNameToObservedStorageSetUID: map[string]string{
+				"node-101": "sset-101",
+				"node-201": "sset-201",
+			},
+			nodeNameToDesiredCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2", "bd-3", "bd-4", "bd-5", "bd-6"},
+				"node-201": []string{"bd-7", "bd-8", "bd-9", "bd-10", "bd-11", "bd-12"},
+			},
+			expectCSPC: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "raidz2-2x6",
+						"namespace": "test-raidz2",
+						"annotations": map[string]interface{}{
+							string(types.AnnKeyCStorClusterPlanUID):   "plan-101",
+							string(types.AnnKeyCStorClusterConfigUID): "config-101",
+						},
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "raidz2",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-101",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-1",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-2",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-3",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-4",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-5",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-6",
+											},
+										},
+										"type":         "raidz2",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "raidz2",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-201",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd-7",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-8",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-9",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-10",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-11",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd-12",
+											},
+										},
+										"type":         "raidz2",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			p := &Planner{
+				ObservedCStorClusterPlan:        mock.observedCStorClusterPlan,
+				ObservedClusterConfig:           mock.observedClusterConfig,
+				desiredRAIDType:                 mock.desiredRAIDType,
+				nodeNameToObservedStorageSetUID: mock.nodeNameToObservedStorageSetUID,
+				nodeNameToDesiredCSPCDevices:    mock.nodeNameToDesiredCSPCDevices,
+			}
+			got := p.getDesiredCStorPoolCluster()
+			expect := mock.expectCSPC
+			// api version check
+			if got.GetAPIVersion() != expect.GetAPIVersion() {
+				t.Fatalf(
+					"Expected api version %s got %s",
+					expect.GetAPIVersion(), got.GetAPIVersion(),
+				)
+			}
+			// kind check
+			if got.GetKind() != expect.GetKind() {
+				t.Fatalf(
+					"Expected kind %s got %s", expect.GetKind(), got.GetKind(),
+				)
+			}
+			// metadata equality check
+			gotMeta := k8s.MustGetNestedMap(got, "metadata")
+			expectMeta := k8s.MustGetNestedMap(expect, "metadata")
+			if !reflect.DeepEqual(gotMeta, expectMeta) {
+				t.Fatalf("Expected cspc meta: [%+v] got: [%+v]", expectMeta, gotMeta)
+			}
+			// pools equality check
+			gotPools := k8s.MustGetNestedSlice(got, "spec", "pools")
+			expectPools := k8s.MustGetNestedSlice(expect, "spec", "pools")
+			gotPoolCount := len(gotPools)
+			expectPoolCount := len(expectPools)
+			if gotPoolCount != expectPoolCount {
+				t.Fatalf("Expected pool count %d got %d", expectPoolCount, gotPoolCount)
+			}
+			var successCount int
+			for idx := range gotPools {
+				for jdx := range expectPools {
+					if reflect.DeepEqual(gotPools[idx], expectPools[jdx]) {
+						// any got index can match any expect index
+						successCount++
+						break
+					}
+				}
+			}
+			if successCount != gotPoolCount {
+				gotJSON, _ := got.MarshalJSON()
+				expectJSON, _ := mock.expectCSPC.MarshalJSON()
+				t.Fatalf("Expected cspc:\n%sGot cspc:\n%s", expectJSON, gotJSON)
+			}
+		})
+	}
+}
+
+func TestPlannerInitNodeToDesiredCSPCDevices(t *testing.T) {
+	var tests = map[string]struct {
+		storageSetToBlockDevices    map[string][]string
+		storageSetUIDToNodeName     map[string]string
+		nodeNameToCSPCDevices       map[string][]string
+		expectNodeNameToCSPCDevices map[string][]string
+		isErr                       bool
+	}{
+		"nil observed block devices": {
+			storageSetToBlockDevices: nil,
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "node-101",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1"},
+			},
+			expectNodeNameToCSPCDevices: nil,
+			isErr:                       false,
+		},
+		"invalid storageset to node": {
+			storageSetToBlockDevices: map[string][]string{
+				"sset-invalid": []string{"bd-invalid-1"},
+			},
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "node-101",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1"},
+			},
+			isErr: true,
+		},
+		"missing storageset uid": {
+			storageSetToBlockDevices: map[string][]string{
+				"": []string{"bd-invalid-1"},
+			},
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "node-101",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1"},
+			},
+			isErr: true,
+		},
+		"missing node": {
+			storageSetToBlockDevices: map[string][]string{
+				"sset-101": []string{"bd-invalid-1"},
+			},
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1"},
+			},
+			isErr: true,
+		},
+		"Mirror - No Change - 3x2 Desired Block Devices & 3x2 Observed CSPC Devices": {
+			storageSetToBlockDevices: map[string][]string{
+				"sset-101": []string{"bd-1", "bd-2"},
+				"sset-201": []string{"bd-3", "bd-4"},
+				"sset-301": []string{"bd-5", "bd-6"},
+			},
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "node-101",
+				"sset-201": "node-201",
+				"sset-301": "node-301",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2"},
+				"node-201": []string{"bd-3", "bd-4"},
+				"node-301": []string{"bd-5", "bd-6"},
+			},
+			expectNodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2"},
+				"node-201": []string{"bd-3", "bd-4"},
+				"node-301": []string{"bd-5", "bd-6"},
+			},
+			isErr: false,
+		},
+		"Mirror - Add - 6x2 Desired Block Devices & 3x2 Observed CSPC Devices": {
+			storageSetToBlockDevices: map[string][]string{
+				"sset-101": []string{"bd-1", "bd-2"},
+				"sset-201": []string{"bd-3", "bd-4"},
+				"sset-301": []string{"bd-5", "bd-6"},
+				"sset-401": []string{"bd-7", "bd-8"},
+				"sset-501": []string{"bd-9", "bd-10"},
+				"sset-601": []string{"bd-11", "bd-12"},
+			},
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "node-101",
+				"sset-201": "node-201",
+				"sset-301": "node-301",
+				"sset-401": "node-401",
+				"sset-501": "node-501",
+				"sset-601": "node-601",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2"},
+				"node-201": []string{"bd-3", "bd-4"},
+				"node-301": []string{"bd-5", "bd-6"},
+			},
+			expectNodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2"},
+				"node-201": []string{"bd-3", "bd-4"},
+				"node-301": []string{"bd-5", "bd-6"},
+				"node-401": []string{"bd-7", "bd-8"},
+				"node-501": []string{"bd-9", "bd-10"},
+				"node-601": []string{"bd-11", "bd-12"},
+			},
+			isErr: false,
+		},
+		"Mirror - Add & Update - 6x2 Desired Block Devices & 3x2 Observed CSPC Devices": {
+			storageSetToBlockDevices: map[string][]string{
+				"sset-101": []string{"bd-1", "bd-22"},
+				"sset-201": []string{"bd-33", "bd-4"},
+				"sset-301": []string{"bd-55", "bd-66"},
+				"sset-401": []string{"bd-7", "bd-8"},
+				"sset-501": []string{"bd-9", "bd-10"},
+				"sset-601": []string{"bd-11", "bd-12"},
+			},
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "node-101",
+				"sset-201": "node-201",
+				"sset-301": "node-301",
+				"sset-401": "node-401",
+				"sset-501": "node-501",
+				"sset-601": "node-601",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2"},
+				"node-201": []string{"bd-3", "bd-4"},
+				"node-301": []string{"bd-5", "bd-6"},
+			},
+			expectNodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-22"},
+				"node-201": []string{"bd-33", "bd-4"},
+				"node-301": []string{"bd-55", "bd-66"},
+				"node-401": []string{"bd-7", "bd-8"},
+				"node-501": []string{"bd-9", "bd-10"},
+				"node-601": []string{"bd-11", "bd-12"},
+			},
+			isErr: false,
+		},
+		"Mirror - Update - 3x2 Desired Block Devices & 3x2 Observed CSPC Devices": {
+			storageSetToBlockDevices: map[string][]string{
+				"sset-101": []string{"bd-1", "bd-22"},
+				"sset-201": []string{"bd-33", "bd-4"},
+				"sset-301": []string{"bd-55", "bd-66"},
+			},
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "node-101",
+				"sset-201": "node-201",
+				"sset-301": "node-301",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2"},
+				"node-201": []string{"bd-3", "bd-4"},
+				"node-301": []string{"bd-5", "bd-6"},
+			},
+			expectNodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-22"},
+				"node-201": []string{"bd-33", "bd-4"},
+				"node-301": []string{"bd-55", "bd-66"},
+			},
+			isErr: false,
+		},
+		"Mirror - Update & Delete - 2x2 Desired Block Devices & 3x2 Observed CSPC Devices": {
+			storageSetToBlockDevices: map[string][]string{
+				"sset-101": []string{"bd-1", "bd-22"},
+				"sset-201": []string{"bd-33", "bd-4"},
+			},
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "node-101",
+				"sset-201": "node-201",
+				"sset-301": "node-301",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2"},
+				"node-201": []string{"bd-3", "bd-4"},
+				"node-301": []string{"bd-5", "bd-6"},
+			},
+			expectNodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-22"},
+				"node-201": []string{"bd-33", "bd-4"},
+			},
+			isErr: false,
+		},
+		"RAIDZ - Delete - 2x3 Desired Block Devices & 3x3 Observed CSPC Devices": {
+			storageSetToBlockDevices: map[string][]string{
+				"sset-101": []string{"bd-1", "bd-2", "bd-3"},
+				"sset-201": []string{"bd-4", "bd-5", "bd-6"},
+			},
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "node-101",
+				"sset-201": "node-201",
+				"sset-301": "node-301",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2", "bd-3"},
+				"node-201": []string{"bd-4", "bd-5", "bd-6"},
+				"node-301": []string{"bd-7", "bd-8", "bd-9"},
+			},
+			expectNodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2", "bd-3"},
+				"node-201": []string{"bd-4", "bd-5", "bd-6"},
+			},
+			isErr: false,
+		},
+		"RAIDZ - Update & Delete - 2x3 Desired Block Devices & 3x3 Observed CSPC Devices": {
+			storageSetToBlockDevices: map[string][]string{
+				"sset-101": []string{"bd-11", "bd-2", "bd-33"},
+				"sset-201": []string{"bd-4", "bd-55", "bd-6"},
+			},
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "node-101",
+				"sset-201": "node-201",
+				"sset-301": "node-301",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2", "bd-3"},
+				"node-201": []string{"bd-4", "bd-5", "bd-6"},
+				"node-301": []string{"bd-7", "bd-8", "bd-9"},
+			},
+			expectNodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-11", "bd-2", "bd-33"},
+				"node-201": []string{"bd-4", "bd-55", "bd-6"},
+			},
+			isErr: false,
+		},
+		"RAIDZ - Add - 4x3 Desired Block Devices & 3x3 Observed CSPC Devices": {
+			storageSetToBlockDevices: map[string][]string{
+				"sset-101": []string{"bd-1", "bd-2", "bd-3"},
+				"sset-201": []string{"bd-4", "bd-5", "bd-6"},
+				"sset-301": []string{"bd-7", "bd-8", "bd-9"},
+				"sset-401": []string{"bd-10", "bd-11", "bd-12"},
+			},
+			storageSetUIDToNodeName: map[string]string{
+				"sset-101": "node-101",
+				"sset-201": "node-201",
+				"sset-301": "node-301",
+				"sset-401": "node-401",
+			},
+			nodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2", "bd-3"},
+				"node-201": []string{"bd-4", "bd-5", "bd-6"},
+				"node-301": []string{"bd-7", "bd-8", "bd-9"},
+			},
+			expectNodeNameToCSPCDevices: map[string][]string{
+				"node-101": []string{"bd-1", "bd-2", "bd-3"},
+				"node-201": []string{"bd-4", "bd-5", "bd-6"},
+				"node-301": []string{"bd-7", "bd-8", "bd-9"},
+				"node-401": []string{"bd-10", "bd-11", "bd-12"},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			p := &Planner{
+				storageSetToObservedBlockDevices: mock.storageSetToBlockDevices,
+				storageSetUIDToObservedNodeName:  mock.storageSetUIDToNodeName,
+				nodeNameToObservedCSPCDevices:    mock.nodeNameToCSPCDevices,
+			}
+			p.initNodeToDesiredCSPCDevices()
+			if len(p.nodeNameToDesiredCSPCDevices) != len(mock.expectNodeNameToCSPCDevices) {
+				t.Fatalf("Expected node to devices mapping count %d got %d",
+					len(mock.expectNodeNameToCSPCDevices), len(p.nodeNameToDesiredCSPCDevices),
+				)
+			}
+			for node, gotDevices := range p.nodeNameToDesiredCSPCDevices {
+				expectDevices := mock.expectNodeNameToCSPCDevices[node]
+				_, adds, deletes := stringutil.NewEquality(expectDevices, gotDevices).Diff()
+				if len(adds) != 0 || len(deletes) != 0 {
+					t.Fatalf(
+						"Expected devices [%+v] got [%+v] at node %s",
+						expectDevices, gotDevices, node,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestPlannerInitStorageSetToObservedBlockDevices(t *testing.T) {
+	var tests = map[string]struct {
+		blockDevices      []*unstructured.Unstructured
+		expectDeviceNames map[string][]string
+		isErr             bool
+	}{
+		"invalid blockdevice": {
+			blockDevices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{},
+			},
+			isErr: true,
+		},
+		"missing storageset uid in label": {
+			blockDevices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":   "no-lbl",
+							"labels": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"single valid blockdevice": {
+			blockDevices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "single-valid",
+							"labels": map[string]interface{}{
+								string(types.AnnKeyCStorClusterStorageSetUID): "101",
+							},
+						},
+					},
+				},
+			},
+			expectDeviceNames: map[string][]string{
+				"101": []string{"single-valid"},
+			},
+			isErr: false,
+		},
+		"multi valid blockdevices": {
+			blockDevices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "multi-valid-1",
+							"labels": map[string]interface{}{
+								string(types.AnnKeyCStorClusterStorageSetUID): "101",
+							},
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "multi-valid-2",
+							"labels": map[string]interface{}{
+								string(types.AnnKeyCStorClusterStorageSetUID): "101",
+							},
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "single-valid",
+							"labels": map[string]interface{}{
+								string(types.AnnKeyCStorClusterStorageSetUID): "201",
+							},
+						},
+					},
+				},
+			},
+			expectDeviceNames: map[string][]string{
+				"101": []string{"multi-valid-1", "multi-valid-2"},
+				"201": []string{"single-valid"},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			p := &Planner{
+				ObservedBlockDevices: mock.blockDevices,
+			}
+			err := p.initStorageSetToObservedBlockDevices()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !mock.isErr {
+				for ssetUID, expectDevices := range mock.expectDeviceNames {
+					gotDevices := p.storageSetToObservedBlockDevices[ssetUID]
+					if len(gotDevices) != len(expectDevices) {
+						t.Fatalf(
+							"Expected device count %d got %d",
+							len(expectDevices), len(gotDevices),
+						)
+					}
+					eq := stringutil.NewEquality(expectDevices, gotDevices)
+					_, adds, removals := eq.Diff()
+					if len(adds) != 0 || len(removals) != 0 {
+						t.Fatalf(
+							"Expected [%+v] got [%+v] for StorageSetUID %s",
+							expectDevices, gotDevices, ssetUID,
+						)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestPlannerInitNodeToObservedCSPCDevices(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "CStorPoolCluster",
+			"apiVersion": "v1",
+			"metadata": map[string]interface{}{
+				"name":      "wow-cstor-pool",
+				"namespace": "mayadata-dao",
+			},
+			"spec": map[string]interface{}{
+				"pools": []interface{}{
+					// pool on node-001
+					map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"defaultRaidGroupType": "mirror",
+							"overProvisioning":     false,
+							"compression":          "off",
+						},
+						"nodeSelector": map[string]interface{}{
+							"kubernetes.io/hostname": "node-001",
+						},
+						// 3 raidGroups per pool
+						"raidGroups": []interface{}{
+							map[string]interface{}{
+								"blockDevices": []interface{}{
+									map[string]interface{}{
+										"blockDeviceName": "bd11",
+									},
+									map[string]interface{}{
+										"blockDeviceName": "bd12",
+									},
+								},
+								"type": "mirror",
+							},
+							map[string]interface{}{
+								"blockDevices": []interface{}{
+									map[string]interface{}{
+										"blockDeviceName": "bd13",
+									},
+									map[string]interface{}{
+										"blockDeviceName": "bd14",
+									},
+								},
+								"type": "mirror",
+							},
+							map[string]interface{}{
+								"blockDevices": []interface{}{
+									map[string]interface{}{
+										"blockDeviceName": "bd15",
+									},
+									map[string]interface{}{
+										"blockDeviceName": "bd16",
+									},
+								},
+								"type": "mirror",
+							},
+						},
+					},
+					// pool on node-002
+					map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"defaultRaidGroupType": "mirror",
+							"overProvisioning":     false,
+							"compression":          "off",
+						},
+						"nodeSelector": map[string]interface{}{
+							"kubernetes.io/hostname": "node-002",
+						},
+						// 3 raidGroups per pool
+						"raidGroups": []interface{}{
+							map[string]interface{}{
+								"blockDevices": []interface{}{
+									map[string]interface{}{
+										"blockDeviceName": "bd21",
+									},
+									map[string]interface{}{
+										"blockDeviceName": "bd22",
+									},
+								},
+								"type": "mirror",
+							},
+							map[string]interface{}{
+								"blockDevices": []interface{}{
+									map[string]interface{}{
+										"blockDeviceName": "bd23",
+									},
+									map[string]interface{}{
+										"blockDeviceName": "bd24",
+									},
+								},
+								"type": "mirror",
+							},
+							map[string]interface{}{
+								"blockDevices": []interface{}{
+									map[string]interface{}{
+										"blockDeviceName": "bd25",
+									},
+									map[string]interface{}{
+										"blockDeviceName": "bd26",
+									},
+								},
+								"type": "mirror",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	var tests = map[string]struct {
+		cspc                  *unstructured.Unstructured
+		isErr                 bool
+		expectedNodeToDevices map[string][]string
+	}{
+		"use above fake cspc obj": {
+			cspc:  obj,
+			isErr: false,
+			expectedNodeToDevices: map[string][]string{
+				"node-001": []string{"bd11", "bd12", "bd13", "bd14", "bd15", "bd16"},
+				"node-002": []string{"bd21", "bd22", "bd23", "bd24", "bd25", "bd26"},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			p := &Planner{
+				ObservedCStorPoolCluster: mock.cspc,
+			}
+			err := p.initNodeToObservedCSPCDevices()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !mock.isErr {
+				if len(p.nodeNameToObservedCSPCDevices) != 2 {
+					t.Fatalf(
+						"Expected pool count 2 got %d: [%+v]",
+						len(p.nodeNameToObservedCSPCDevices),
+						p.nodeNameToObservedCSPCDevices,
+					)
+				}
+				for nodeName, actualDevices := range p.nodeNameToObservedCSPCDevices {
+					expectedDevices := mock.expectedNodeToDevices[nodeName]
+					if len(expectedDevices) != len(actualDevices) {
+						t.Fatalf(
+							"Expected block device count %d got %d: NodeName %q",
+							len(expectedDevices),
+							len(actualDevices),
+							nodeName,
+						)
+					}
+					for idx, expectedDevice := range expectedDevices {
+						if actualDevices[idx] != expectedDevice {
+							t.Fatalf(
+								"Expected block device %q got %q at index %d: NodeName %q",
+								expectedDevice, actualDevices[idx], idx, nodeName,
+							)
+						}
+					}
+				}
+			}
+		})
+	}
+}
 
 func TestPlannerIsReadyByNodeCount(t *testing.T) {
 	var tests = map[string]struct {
@@ -32,7 +1305,7 @@ func TestPlannerIsReadyByNodeCount(t *testing.T) {
 	}{
 		"node count == observed storageset count": {
 			planner: &Planner{
-				CStorClusterPlan: &types.CStorClusterPlan{
+				ObservedCStorClusterPlan: &types.CStorClusterPlan{
 					Spec: types.CStorClusterPlanSpec{
 						Nodes: []types.CStorClusterPlanNode{
 							types.CStorClusterPlanNode{},
@@ -49,7 +1322,7 @@ func TestPlannerIsReadyByNodeCount(t *testing.T) {
 		},
 		"node count < observed storageset count": {
 			planner: &Planner{
-				CStorClusterPlan: &types.CStorClusterPlan{
+				ObservedCStorClusterPlan: &types.CStorClusterPlan{
 					Spec: types.CStorClusterPlanSpec{
 						Nodes: []types.CStorClusterPlanNode{
 							types.CStorClusterPlanNode{},
@@ -65,7 +1338,7 @@ func TestPlannerIsReadyByNodeCount(t *testing.T) {
 		},
 		"node count > observed storageset count": {
 			planner: &Planner{
-				CStorClusterPlan: &types.CStorClusterPlan{
+				ObservedCStorClusterPlan: &types.CStorClusterPlan{
 					Spec: types.CStorClusterPlanSpec{
 						Nodes: []types.CStorClusterPlanNode{
 							types.CStorClusterPlanNode{},
@@ -108,7 +1381,7 @@ func TestPlannerIsReadyByNodeDiskCount(t *testing.T) {
 				storageSetToDesiredDiskCount: map[string]resource.Quantity{
 					"101": resource.MustParse("1"),
 				},
-				storageSetToBlockDevices: map[string][]string{
+				storageSetToObservedBlockDevices: map[string][]string{
 					"101": []string{"bd1"},
 				},
 			},
@@ -118,11 +1391,11 @@ func TestPlannerIsReadyByNodeDiskCount(t *testing.T) {
 			planner: &Planner{
 				// TODO (@amitkumardas):
 				// 	Use log as a field in Planner
-				CStorClusterPlan: mockloginfo,
+				ObservedCStorClusterPlan: mockloginfo,
 				storageSetToDesiredDiskCount: map[string]resource.Quantity{
 					"101": resource.MustParse("2"),
 				},
-				storageSetToBlockDevices: map[string][]string{
+				storageSetToObservedBlockDevices: map[string][]string{
 					"101": []string{"bd1"},
 				},
 			},
@@ -133,7 +1406,7 @@ func TestPlannerIsReadyByNodeDiskCount(t *testing.T) {
 				storageSetToDesiredDiskCount: map[string]resource.Quantity{
 					"101": resource.MustParse("2"),
 				},
-				storageSetToBlockDevices: map[string][]string{
+				storageSetToObservedBlockDevices: map[string][]string{
 					"101": []string{"bd1", "bd2", "bd3"},
 				},
 			},

--- a/k8s/condition.go
+++ b/k8s/condition.go
@@ -219,7 +219,7 @@ func (e *Condition) hasPair(pairs map[string]string, key, value string) bool {
 		)
 		return false
 	}
-	got, _ := GetAnnotationForKey(pairs, key)
+	got, _ := GetValueForKey(pairs, key)
 	return got == value
 }
 

--- a/k8s/iterator.go
+++ b/k8s/iterator.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// UnstructOpsFn is a typed function that abstracts operations
+// against an unstructured instance
+type UnstructOpsFn func(*unstructured.Unstructured) error
+
+// SliceIteration provides iteration operations against its
+// list of items
+type SliceIteration struct {
+	Items []interface{}
+}
+
+// AsUnstruct transforms the provided instance into appropriate
+// unstructured instance
+func (i SliceIteration) AsUnstruct(idx int, given interface{}) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetUnstructuredContent(
+		map[string]interface{}{
+			"spec": given,
+		},
+	)
+	u.SetKind("SliceItem")
+	u.SetAPIVersion("v1")
+	u.SetName(fmt.Sprintf("elem-%d", idx))
+	return u
+}
+
+// SliceIterator is the constructor that returns a new instance of
+// SliceIteration
+func SliceIterator(items []interface{}) *SliceIteration {
+	return &SliceIteration{Items: items}
+}
+
+// ForEach loops through this instances list and runs each of the
+// item against the provided functions
+func (i *SliceIteration) ForEach(must UnstructOpsFn, others ...UnstructOpsFn) error {
+	var unFns []UnstructOpsFn
+	unFns = append(unFns, must)
+	unFns = append(unFns, others...)
+	for idx, elem := range i.Items {
+		un := i.AsUnstruct(idx, elem)
+		for _, fn := range unFns {
+			err := fn(un)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/k8s/iterator_test.go
+++ b/k8s/iterator_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestUnstructIterator(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "CSPC",
+			"apiVersion": "v2beta1",
+			"metadata": map[string]interface{}{
+				"name":      "my-cstor-pool",
+				"namespace": "openebs-dao",
+			},
+			"spec": map[string]interface{}{
+				"pools": []interface{}{
+					// pool on node-001
+					map[string]interface{}{
+						"nodeSelector": map[string]interface{}{
+							"kubernetes.io/hostname": "node-001",
+						},
+						"raidGroups": []interface{}{
+							map[string]interface{}{
+								"blockDevices": []interface{}{
+									map[string]interface{}{
+										"blockDeviceName": "bd11",
+									},
+									map[string]interface{}{
+										"blockDeviceName": "bd12",
+									},
+								},
+								"type": "mirror",
+							},
+							map[string]interface{}{
+								"blockDevices": []interface{}{
+									map[string]interface{}{
+										"blockDeviceName": "bd13",
+									},
+									map[string]interface{}{
+										"blockDeviceName": "bd14",
+									},
+								},
+								"type": "mirror",
+							},
+						},
+					},
+					// pool on node-002
+					map[string]interface{}{
+						"nodeSelector": map[string]interface{}{
+							"kubernetes.io/hostname": "node-002",
+						},
+						"raidGroups": []interface{}{
+							map[string]interface{}{
+								"blockDevices": []interface{}{
+									map[string]interface{}{
+										"blockDeviceName": "bd21",
+									},
+									map[string]interface{}{
+										"blockDeviceName": "bd22",
+									},
+								},
+								"type": "mirror",
+							},
+							map[string]interface{}{
+								"blockDevices": []interface{}{
+									map[string]interface{}{
+										"blockDeviceName": "bd23",
+									},
+									map[string]interface{}{
+										"blockDeviceName": "bd24",
+									},
+								},
+								"type": "mirror",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	tests := map[string]struct {
+		obj                *unstructured.Unstructured
+		getNodeName        UnstructOpsFn
+		getBlockDeviceName UnstructOpsFn
+		isErr              bool
+	}{
+		"no errors": {
+			obj: obj,
+			getNodeName: func(obj *unstructured.Unstructured) (err error) {
+				_, err =
+					GetStringOrError(obj, "spec", "nodeSelector", "kubernetes.io/hostname")
+				return
+			},
+			getBlockDeviceName: func(obj *unstructured.Unstructured) (err error) {
+				_, err = GetStringOrError(obj, "spec", "blockDeviceName")
+				return
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			getBlockDevicesPerRAIDGroup := func(obj *unstructured.Unstructured) error {
+				blockDevices, err := GetSliceOrError(obj, "spec", "blockDevices")
+				if err != nil {
+					return err
+				}
+				return SliceIterator(blockDevices).ForEach(mock.getBlockDeviceName)
+			}
+			getBlockDevicesPerPool := func(obj *unstructured.Unstructured) error {
+				raidGroups, err := GetSliceOrError(obj, "spec", "raidGroups")
+				if err != nil {
+					return err
+				}
+				return SliceIterator(raidGroups).ForEach(getBlockDevicesPerRAIDGroup)
+			}
+			pools, err := GetSliceOrError(mock.obj, "spec", "pools")
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if mock.isErr {
+				return
+			}
+			err = SliceIterator(pools).ForEach(mock.getNodeName, getBlockDevicesPerPool)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+		})
+	}
+}

--- a/types/cstorclusterconfig.go
+++ b/types/cstorclusterconfig.go
@@ -118,6 +118,15 @@ const (
 	PoolRAIDTypeDefault PoolRAIDType = PoolRAIDTypeMirror
 )
 
+// RAIDTypeToDefaultMinDiskCount maps pool instance's raid type
+// to its default minimum disk count
+var RAIDTypeToDefaultMinDiskCount = map[PoolRAIDType]int64{
+	PoolRAIDTypeMirror: 2,
+	PoolRAIDTypeStripe: 1,
+	PoolRAIDTypeRAIDZ:  3,
+	PoolRAIDTypeRAIDZ2: 6,
+}
+
 // CStorClusterConfigStatus represents the current state of
 // CStorClusterConfig
 type CStorClusterConfigStatus struct {

--- a/util/string/string.go
+++ b/util/string/string.go
@@ -21,6 +21,10 @@ import "strings"
 // List is a representation of list of strings
 type List []string
 
+// Map is a mapped representation of string with
+// boolean value
+type Map map[string]bool
+
 // String implements Stringer interface
 func (l List) String() string {
 	return strings.Join(l, ", ")
@@ -46,4 +50,85 @@ func (l List) Contains(substr string) bool {
 		}
 	}
 	return false
+}
+
+// Equality helps in finding difference or merging
+// list of string based items.
+type Equality struct {
+	src  List
+	dest List
+}
+
+// NewEquality returns a populated Equality structure
+func NewEquality(src, dest List) Equality {
+	return Equality{
+		src:  src,
+		dest: dest,
+	}
+}
+
+// Diff finds the difference between source list & destination
+// list and returns the no change, addition & removal items
+// respectively
+func (e Equality) Diff() (noops Map, additions []string, removals []string) {
+	noops = map[string]bool{}
+	for _, source := range e.src {
+		if e.dest.ContainsExact(source) {
+			noops[source] = true
+			continue
+		}
+		removals = append(removals, source)
+	}
+	for _, destination := range e.dest {
+		if e.src.ContainsExact(destination) {
+			continue
+		}
+		additions = append(additions, destination)
+	}
+	return
+}
+
+// Merge merges the source items with destination items
+// by keeping the order of source items. Source items that
+// need to be replaced as replaced from new destination
+// items. It appends new used items to the end of the resulting
+// list.
+func (e Equality) Merge() []string {
+	var new []string
+	var used = map[string]bool{}
+	var merge []string
+	for _, destItem := range e.dest {
+		if e.src.ContainsExact(destItem) {
+			// nothing to be done here
+			continue
+		}
+		// store this is a new item
+		new = append(new, destItem)
+	}
+	// we want to merge by following the order of source list
+	for _, sourceItem := range e.src {
+		if e.dest.ContainsExact(sourceItem) {
+			// no change; use this as merge item
+			merge = append(merge, sourceItem)
+			continue
+		}
+		// donot use this source item
+		// replace source item with a new item if available
+		if len(new) == 0 {
+			continue
+		}
+		newItem := new[len(used)]
+		merge = append(merge, newItem)
+		// mark this new item as used
+		used[newItem] = true
+	}
+	// check for extras
+	for _, newItem := range new {
+		if len(used) == 0 || !used[newItem] {
+			// use this new item since it has not been
+			// used as a replacement previously
+			merge = append(merge, newItem)
+		}
+	}
+	return merge
 }

--- a/util/string/string_test.go
+++ b/util/string/string_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package string
+
+import "testing"
+
+func TestEqualityDiff(t *testing.T) {
+	var tests = map[string]struct {
+		src      List
+		dest     List
+		noops    map[string]bool
+		adds     []string
+		removals []string
+	}{
+		"src == dest": {
+			src:  List([]string{"hi", "hello"}),
+			dest: List([]string{"hi", "hello"}),
+			noops: map[string]bool{
+				"hi":    true,
+				"hello": true,
+			},
+			adds:     nil,
+			removals: nil,
+		},
+		"src != dest; extra values in dest": {
+			src:  List([]string{"hi", "hello"}),
+			dest: List([]string{"hi", "hello", "there", "how are you"}),
+			noops: map[string]bool{
+				"hi":    true,
+				"hello": true,
+			},
+			adds:     []string{"there", "how are you"},
+			removals: nil,
+		},
+		"src != dest; missing values in dest": {
+			src:  List([]string{"hi", "hello"}),
+			dest: List([]string{"hello"}),
+			noops: map[string]bool{
+				"hello": true,
+			},
+			adds:     nil,
+			removals: []string{"hi"},
+		},
+		"src != dest; missing & new values in dest": {
+			src:  List([]string{"hi", "hello"}),
+			dest: List([]string{"hello", "how", "are", "you"}),
+			noops: map[string]bool{
+				"hello": true,
+			},
+			adds:     []string{"how", "are", "you"},
+			removals: []string{"hi"},
+		},
+		"src != dest; nil src": {
+			src:      List(nil),
+			dest:     List([]string{"hello", "how", "are", "you"}),
+			noops:    map[string]bool{},
+			adds:     []string{"hello", "how", "are", "you"},
+			removals: nil,
+		},
+		"src != dest; empty src": {
+			src:      List([]string{}),
+			dest:     List([]string{"hello", "how", "are", "you"}),
+			noops:    map[string]bool{},
+			adds:     []string{"hello", "how", "are", "you"},
+			removals: nil,
+		},
+		"src != dest; nil dest": {
+			src:      List([]string{"hi", "hello"}),
+			dest:     List(nil),
+			noops:    map[string]bool{},
+			adds:     nil,
+			removals: []string{"hi", "hello"},
+		},
+		"src != dest; empty dest": {
+			src:      List([]string{"hi", "hello"}),
+			dest:     List([]string{}),
+			noops:    map[string]bool{},
+			adds:     nil,
+			removals: []string{"hi", "hello"},
+		},
+		"src == dest == nil": {
+			src:      List(nil),
+			dest:     List(nil),
+			noops:    map[string]bool{},
+			adds:     nil,
+			removals: nil,
+		},
+		"src == dest == empty": {
+			src:      List([]string{}),
+			dest:     List([]string{}),
+			noops:    map[string]bool{},
+			adds:     nil,
+			removals: nil,
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := &Equality{
+				src:  mock.src,
+				dest: mock.dest,
+			}
+			noops, adds, removals := e.Diff()
+			if len(noops) != len(mock.noops) {
+				t.Fatalf("Expected noops [%+v] got [%+v]", mock.noops, noops)
+			}
+			if len(adds) != len(mock.adds) {
+				t.Fatalf("Expected adds count %d got %d", len(mock.adds), len(adds))
+			}
+			if len(removals) != len(mock.removals) {
+				t.Fatalf("Expected removals count %d got %d", len(mock.removals), len(removals))
+			}
+			addsList := List(adds)
+			for _, addItem := range mock.adds {
+				if !addsList.ContainsExact(addItem) {
+					t.Fatalf("Expected adds [%+v] got [%+v]", mock.adds, adds)
+				}
+			}
+			removalList := List(removals)
+			for _, removalItem := range mock.removals {
+				if !removalList.ContainsExact(removalItem) {
+					t.Fatalf("Expected removals [%+v] got [%+v]", mock.removals, removals)
+				}
+			}
+		})
+	}
+}
+
+func TestEqualityMerge(t *testing.T) {
+	var tests = map[string]struct {
+		src    List
+		dest   List
+		expect []string
+	}{
+		"src == dest": {
+			src:    List([]string{"hi", "hello"}),
+			dest:   List([]string{"hi", "hello"}),
+			expect: []string{"hi", "hello"},
+		},
+		"src != dest; extra values in dest": {
+			src:    List([]string{"hi", "hello"}),
+			dest:   List([]string{"hi", "hello", "there", "how are you"}),
+			expect: []string{"hi", "hello", "there", "how are you"},
+		},
+		"src != dest; missing values in dest": {
+			src:    List([]string{"hi", "hello"}),
+			dest:   List([]string{"hello"}),
+			expect: []string{"hello"},
+		},
+		"src != dest; missing & new values in dest": {
+			src:  List([]string{"hi", "hello"}),
+			dest: List([]string{"hello", "how", "are", "you"}),
+			// note that order of src is maintained
+			expect: []string{"how", "hello", "are", "you"},
+		},
+		"src != dest; multiple missing & multiple new values in dest": {
+			src:  List([]string{"hi", "hello", "app", "cstor", "type", "nice"}),
+			dest: List([]string{"hello", "nice", "how", "are", "you", "app"}),
+			// note that order of src is maintained
+			expect: []string{"how", "hello", "app", "are", "you", "nice"},
+		},
+		"src != dest; nil src": {
+			src:    List(nil),
+			dest:   List([]string{"hello", "how", "are", "you"}),
+			expect: []string{"hello", "how", "are", "you"},
+		},
+		"src != dest; empty src": {
+			src:    List([]string{}),
+			dest:   List([]string{"hello", "how", "are", "you"}),
+			expect: []string{"hello", "how", "are", "you"},
+		},
+		"src != dest; nil dest": {
+			src:    List([]string{"hi", "hello"}),
+			dest:   List(nil),
+			expect: nil,
+		},
+		"src != dest; empty dest": {
+			src:    List([]string{"hi", "hello"}),
+			dest:   List([]string{}),
+			expect: nil,
+		},
+		"src == dest == nil": {
+			src:    List(nil),
+			dest:   List(nil),
+			expect: nil,
+		},
+		"src == dest == empty": {
+			src:    List([]string{}),
+			dest:   List([]string{}),
+			expect: nil,
+		},
+	}
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			e := &Equality{
+				src:  mock.src,
+				dest: mock.dest,
+			}
+			got := e.Merge()
+			if len(got) != len(mock.expect) {
+				t.Fatalf("Expected [%+v] got [%+v]", mock.expect, got)
+			}
+			for idx, gotItem := range got {
+				if gotItem != mock.expect[idx] {
+					t.Fatalf("Expected %s got %s at index %d", mock.expect[idx], gotItem, idx)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit fixes the placement of raid groups in CSPC. Earlier logic used to result only in a single raidgroup for all RAID types. With this change, a mirror will have one or more raid groups with each
raid group having 2 block disks. Similarly raidz will have one or more raid groups with each raid group having 3 block disks.

There are additional improvements w.r.t utility functions for unstructured instances and string list.

closes https://github.com/mayadata-io/cstorpoolauto/issues/59

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>