### PR TITLE
feat(recommendation): add schema for CStorPoolcluster recommendation

### DIFF
--- a/types/recommendation.go
+++ b/types/recommendation.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CStorPoolClusterRecommendation is a kubernetes custom
+// resource that represents recommended configurations
+// for one given input/requirement.
+type CStorPoolClusterRecommendation struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+
+	RequestSpec CStorPoolClusterRecommendationRequestSpec `json:"requestSpec"`
+
+	Spec CStorPoolClusterRecommendationSpec `json:"spec"`
+}
+
+// CStorPoolClusterRecommendationSpec contains recommended
+// pool instance config.
+type CStorPoolClusterRecommendationSpec struct {
+	PoolInstances []PoolInstanceConfig `json:"poolInstances"`
+}
+
+// PoolInstanceConfig contains node identity capacity
+// and selected block devices for that.
+type PoolInstanceConfig struct {
+	Node Reference `json:"node"`
+	// Capacity represents capacity for one pool instance
+	Capacity resource.Quantity `json:"capacity"`
+	// DataDevices contains list of data, read-cache and
+	// write-cache block devices associated with the node.
+	BlockDevices BlockDeviceTopology `json:"blockDevices"`
+}
+
+// BlockDeviceTopology contains block device lists which will be
+// used for data read and write cache.
+type BlockDeviceTopology struct {
+	// DataDevices contains list of block devices associated
+	// with the node which will be used for data device.
+	DataDevices []Reference `json:"dataDevices"`
+	// DataDevices contains list of block devices associated
+	// with the node which will be used for read cache.
+	ReadCacheDevices []Reference `json:"readCacheDevices"`
+	// DataDevices contains list of block devices associated
+	// with the node which will be used for write cache.
+	WriteCacheDevices []Reference `json:"writeCacheDevices"`
+}

--- a/types/recommendation.go
+++ b/types/recommendation.go
@@ -25,7 +25,10 @@ import (
 // resource that represents recommended configurations
 // for one given input/requirement.
 type CStorPoolClusterRecommendation struct {
-	metav1.TypeMeta   `json:",inline"`
+	// Commented it out for now as we - don't introduce a variable
+	// if you are planing to use it in future
+	// Will bring it back when we will create CR(s)
+	// metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
 	RequestSpec CStorPoolClusterRecommendationRequestSpec `json:"requestSpec"`
@@ -57,9 +60,11 @@ type BlockDeviceTopology struct {
 	// with the node which will be used for data device.
 	DataDevices []Reference `json:"dataDevices"`
 	// DataDevices contains list of block devices associated
-	// with the node which will be used for read cache.
-	ReadCacheDevices []Reference `json:"readCacheDevices"`
-	// DataDevices contains list of block devices associated
 	// with the node which will be used for write cache.
 	WriteCacheDevices []Reference `json:"writeCacheDevices"`
+	// Commented it out for now as we - don't introduce a variable
+	// if you are planing to use it in future
+	// DataDevices contains list of block devices associated
+	// with the node which will be used for read cache.
+	// ReadCacheDevices []Reference `json:"readCacheDevices"`
 }

--- a/types/recommendationrequest.go
+++ b/types/recommendationrequest.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CStorPoolClusterRecommendationRequest is a kubernetes custom
+// resource that represents configuration input or requirement
+// to create or scale one CStor pool.
+type CStorPoolClusterRecommendationRequest struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+
+	Spec CStorPoolClusterRecommendationRequestSpec `json:"spec"`
+}
+
+// CStorPoolClusterRecommendationRequestSpec contains input or requirement
+// to create or scale one CStorpoolcluster.
+type CStorPoolClusterRecommendationRequestSpec struct {
+	// PoolCapacity represents requested capacity for one pool
+	PoolCapacity resource.Quantity `json:"poolCapacity"`
+	// DataConfig represents raid configuration for data devices.
+	DataConfig RaidGroupConfig `json:"dataConfig"`
+	// WriteCacheConfig represents raid configuration for write cache devices.
+	// If this field is nil then write cache is disabled.
+	WriteCacheConfig *RaidGroupConfig `json:"writeCacheConfig"`
+	// ReadCacheConfig represents raid configuration for read cache devices.
+	// If this field is nil then read cache is disabled.
+	ReadCacheConfig *RaidGroupConfig `json:"readCacheConfig"`
+}
+
+// RaidGroupConfig contains raid type and device(s)
+// count for a raid group
+type RaidGroupConfig struct {
+	// Type is the raid group type
+	// Supported values are : stripe, mirror, raidz and raidz2
+	Type string `json:"type"`
+	// GroupDeviceCount contains device count in a raid group
+	// -- for stripe DeviceCount = 1
+	// -- for mirror DeviceCount = 2
+	// -- for raidz DeviceCount = (2^n + 1) default is (2 + 1)
+	// -- for raidz2 DeviceCount = (2^n + 2) default is (4 + 2)
+	GroupDeviceCount int64 `json:"groupDeviceCount"`
+}

--- a/types/recommendationrequest.go
+++ b/types/recommendationrequest.go
@@ -25,7 +25,10 @@ import (
 // resource that represents configuration input or requirement
 // to create or scale one CStor pool.
 type CStorPoolClusterRecommendationRequest struct {
-	metav1.TypeMeta   `json:",inline"`
+	// Commented it out for now as we - don't introduce a variable
+	// if you are planing to use it in future
+	// Will bring it back when we will create CR(s)
+	// metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec CStorPoolClusterRecommendationRequestSpec `json:"spec"`
@@ -43,7 +46,9 @@ type CStorPoolClusterRecommendationRequestSpec struct {
 	WriteCacheConfig *RaidGroupConfig `json:"writeCacheConfig"`
 	// ReadCacheConfig represents raid configuration for read cache devices.
 	// If this field is nil then read cache is disabled.
-	ReadCacheConfig *RaidGroupConfig `json:"readCacheConfig"`
+	// Commented it out for now as we - don't introduce a variable
+	// if you are planing to use it in future
+	// ReadCacheConfig *RaidGroupConfig `json:"readCacheConfig"`
 }
 
 // RaidGroupConfig contains raid type and device(s)

--- a/types/reference.go
+++ b/types/reference.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Reference contains enough information
+// to let you identify one Kubernetes object.
+type Reference struct {
+	// API version of the referent.
+	APIVersion string `json:"apiVersion"`
+	// Kind of the referent.
+	Kind string `json:"kind"`
+	// Name of the referent.
+	Name string `json:"name"`
+	// Namespace of the referent.
+	Namespace string `json:"namespace"`
+	// UID of the referent.
+	UID types.UID `json:"uid"`
+}


### PR DESCRIPTION
This PR adds 2 new schemas required to implement the Recommendation feature. 
[Design doc here](https://docs.google.com/document/d/1N78m0mTjEZ9iX4n73kcajpy13DqLpApzt8oBiJjO_6c)

This PR adds 2 new schemas required to implement the Recommendation feature.
```
1. CStorPoolClusterRecommendationRequest
2. CStorPoolClusterRecommendation
```
Schema for CStorPoolClusterRecommendationRequest
```go
import (
	"k8s.io/apimachinery/pkg/api/resource"
	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
)

// CStorPoolClusterRecommendationRequest is a kubernetes custom
// resource that represents configuration input or requirement
// to create or scale one CStor pool.
type CStorPoolClusterRecommendationRequest struct {
	metav1.TypeMeta   `json:",inline"`
	metav1.ObjectMeta `json:"metadata"`

	Spec CStorPoolClusterRecommendationRequestSpec `json:"spec"`
}

// CStorPoolClusterRecommendationRequestSpec contains input or requirement
// to create or scale one CStorpoolcluster.
type CStorPoolClusterRecommendationRequestSpec struct {
	// PoolCapacity represents requested capacity for one pool
	PoolCapacity resource.Quantity `json:"poolCapacity"`
	// DataConfig represents raid configuration for data devices.
	DataConfig RaidGroupConfig `json:"dataConfig"`
	// WriteCacheConfig represents raid configuration for write cache devices.
	// If this field is nil then write cache is disabled.
	WriteCacheConfig *RaidGroupConfig `json:"writeCacheConfig"`
	// ReadCacheConfig represents raid configuration for read cache devices.
	// If this field is nil then read cache is disabled.
	ReadCacheConfig *RaidGroupConfig `json:"readCacheConfig"`
}

// RaidGroupConfig contains raid type and device(s)
// count for a raid group
type RaidGroupConfig struct {
	// Type is the raid group type
	// Supported values are : stripe, mirror, raidz and raidz2
	Type string `json:"type"`
	// GroupDeviceCount contains device count in a raid group
	// -- for stripe DeviceCount = 1
	// -- for mirror DeviceCount = 2
	// -- for raidz DeviceCount = (2^n + 1) default is (2 + 1)
	// -- for raidz2 DeviceCount = (2^n + 2) default is (4 + 2)
	GroupDeviceCount int64 `json:"groupDeviceCount"`
}
```
Schema for CStorPoolClusterRecommendation
```go
import (
	"k8s.io/apimachinery/pkg/api/resource"
	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
	"k8s.io/apimachinery/pkg/types"
)

// CStorPoolClusterRecommendation is a kubernetes custom
// resource that represents recommended configurations
// for one given input/requirement.
type CStorPoolClusterRecommendation struct {
	metav1.TypeMeta   `json:",inline"`
	metav1.ObjectMeta `json:"metadata"`

	RequestSpec CStorPoolClusterRecommendationRequestSpec `json:"requestSpec"`

	Spec CStorPoolClusterRecommendationSpec `json:"spec"`
}

// CStorPoolClusterRecommendationSpec contains recommended
// pool instance config.
type CStorPoolClusterRecommendationSpec struct {
	PoolInstances []PoolInstanceConfig `json:"poolInstances"`
}

// PoolInstanceConfig contains node identity capacity
// and selected block devices for that.
type PoolInstanceConfig struct {
	Node Reference `json:"node"`
	// Capacity represents capacity for one pool instance
	Capacity resource.Quantity `json:"capacity"`
	// DataDevices contains list of data, read-cache and
	// write-cache block devices associated with the node.
	BlockDevices BlockDeviceTopology `json:"blockDevices"`
}

// BlockDeviceTopology contains block device lists which will be
// used for data read and write cache.
type BlockDeviceTopology struct {
	// DataDevices contains list of block devices associated
	// with the node which will be used for data device.
	DataDevices []Reference `json:"dataDevices"`
	// DataDevices contains list of block devices associated
	// with the node which will be used for read cache.
	ReadCacheDevices []Reference `json:"readCacheDevices"`
	// DataDevices contains list of block devices associated
	// with the node which will be used for write cache.
	WriteCacheDevices []Reference `json:"writeCacheDevices"`
}

// Reference contains enough information
// to let you identify an kubernetes object.
type Reference struct {
	// API version of the referent.
	APIVersion string `json:"apiVersion"`
	// Kind of the referent.
	Kind string `json:"kind"`
	// Name of the referent.
	Name string `json:"name"`
	// Namespace of the referent.
	Namespace string `json:"namespace"`
	// UID of the referent.
	UID types.UID `json:"uid"`
}
```