### PR TITLE
fix(maxpoolcount): fix updating max pool count

### DIFF
--- a/controller/cstorclusterplan/reconciler.go
+++ b/controller/cstorclusterplan/reconciler.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"openebs.io/metac/controller/generic"
 
-	"mayadata.io/cstorpoolauto/unstruct"
 	"mayadata.io/cstorpoolauto/types"
+	"mayadata.io/cstorpoolauto/unstruct"
 	"mayadata.io/cstorpoolauto/util/metac"
 )
 
@@ -45,7 +45,7 @@ func (h *reconcileErrHandler) handle(err error) {
 	)
 
 	conds, mergeErr :=
-	unstruct.MergeStatusConditions(
+		unstruct.MergeStatusConditions(
 			h.clusterPlan,
 			types.MakeCStorClusterPlanReconcileErrCond(err),
 		)
@@ -402,7 +402,7 @@ func (p *StorageSetListPlanner) sync() ([]*unstructured.Unstructured, error) {
 
 		storageSets = append(
 			storageSets,
-			p.getStorageSetDesiredState(
+			p.getDesiredStorageSet(
 				p.ObservedStorageSetObjs[uid].GetName(), uid,
 			),
 		)
@@ -433,7 +433,7 @@ func (p *StorageSetListPlanner) create() []*unstructured.Unstructured {
 		// creation of only one instance of CStorClusterStorageSet
 		storageSetName := p.ClusterPlan.GetName() + "-" + nodeUID
 		storageSets = append(
-			storageSets, p.getStorageSetDesiredState(storageSetName, nodeUID),
+			storageSets, p.getDesiredStorageSet(storageSetName, nodeUID),
 		)
 	}
 	return storageSets
@@ -476,19 +476,19 @@ func (p *StorageSetListPlanner) updateNode() ([]*unstructured.Unstructured, erro
 
 		updatedStorageSets = append(
 			updatedStorageSets,
-			p.getStorageSetDesiredState(storageSet.GetName(), newNodeUID),
+			p.getDesiredStorageSet(storageSet.GetName(), newNodeUID),
 		)
 	}
 	return updatedStorageSets, nil
 }
 
-// getStorageSetDesiredState returns the desired state of StorageSet
+// getDesiredStorageSet returns the desired state of StorageSet
 // based on the given node UID.
 //
 // NOTE:
 //	The returned instance is idempotent and hence can be used during
 // create & update operations
-func (p *StorageSetListPlanner) getStorageSetDesiredState(
+func (p *StorageSetListPlanner) getDesiredStorageSet(
 	storageSetName string, nodeUID string,
 ) *unstructured.Unstructured {
 	storageSet := &unstructured.Unstructured{}
@@ -506,9 +506,9 @@ func (p *StorageSetListPlanner) getStorageSetDesiredState(
 				"capacity": p.ClusterConfig.Spec.DiskConfig.MinCapacity,
 				"count":    p.ClusterConfig.Spec.DiskConfig.MinCount,
 			},
-			"externalProvisioner": map[string]interface{}{
-				"csiAttacherName":  p.ClusterConfig.Spec.DiskConfig.ExternalProvisioner.CSIAttacherName,
-				"storageClassName": p.ClusterConfig.Spec.DiskConfig.ExternalProvisioner.StorageClassName,
+			"externalDiskConfig": map[string]interface{}{
+				"csiAttacherName":  p.ClusterConfig.Spec.DiskConfig.ExternalDiskConfig.CSIAttacherName,
+				"storageClassName": p.ClusterConfig.Spec.DiskConfig.ExternalDiskConfig.StorageClassName,
 			},
 		},
 	})

--- a/controller/cstorclusterstorageset/reconciler.go
+++ b/controller/cstorclusterstorageset/reconciler.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"openebs.io/metac/controller/generic"
 
-	"mayadata.io/cstorpoolauto/unstruct"
 	"mayadata.io/cstorpoolauto/types"
+	"mayadata.io/cstorpoolauto/unstruct"
 	"mayadata.io/cstorpoolauto/util/metac"
 )
 
@@ -49,7 +49,7 @@ func (h *reconcileErrHandler) handle(err error) {
 	)
 
 	conds, mergeErr :=
-	unstruct.MergeStatusConditions(
+		unstruct.MergeStatusConditions(
 			h.storageSet,
 			types.MakeCStorClusterStorageSetReconcileErrCond(err),
 		)
@@ -238,8 +238,8 @@ func NewStoragePlanner(storageSet *types.CStorClusterStorageSet) *StoragePlanner
 		DesiredCapacity:         storageSet.Spec.Disk.Capacity,
 		DesiredNodeName:         storageSet.Spec.Node.Name,
 		DesiredNamespace:        storageSet.GetNamespace(),
-		DesiredCSIAttacherName:  storageSet.Spec.ExternalProvisioner.CSIAttacherName,
-		DesiredStorageClassName: storageSet.Spec.ExternalProvisioner.StorageClassName,
+		DesiredCSIAttacherName:  storageSet.Spec.ExternalDiskConfig.CSIAttacherName,
+		DesiredStorageClassName: storageSet.Spec.ExternalDiskConfig.StorageClassName,
 	}
 }
 
@@ -262,16 +262,16 @@ func (p *StoragePlanner) plan(count int64) []*unstructured.Unstructured {
 			"Will sync Storage %d for CStorClusterStorageSet UID %q", i, p.StorageSetUID,
 		)
 		storageName := p.StorageSetName + "-" + strconv.FormatInt(i, 10)
-		desiredStorages = append(desiredStorages, p.getStorageDesiredState(storageName))
+		desiredStorages = append(desiredStorages, p.getDesiredStorage(storageName))
 	}
 	return desiredStorages
 }
 
-// getStorageDesiredState returns the desired state of the
+// getDesiredStorage returns the desired state of the
 // Storage resource. This returned structure is idempotent
 // and hence can be used during create &/ update based
 // reconciliations.
-func (p *StoragePlanner) getStorageDesiredState(storageName string) *unstructured.Unstructured {
+func (p *StoragePlanner) getDesiredStorage(storageName string) *unstructured.Unstructured {
 	storage := &unstructured.Unstructured{}
 	storage.SetUnstructuredContent(map[string]interface{}{
 		"metadata": map[string]interface{}{

--- a/controller/cstorpoolcluster/reconciler.go
+++ b/controller/cstorpoolcluster/reconciler.go
@@ -529,8 +529,8 @@ func (p *Planner) initNodeToObservedCSPCDevices() error {
 	)
 }
 
-// initNodeToDesiredCSPCDevices maps node name to desired
-// BlockDevice(s)
+// initNodeToDesiredCSPCDevices manages reconciling the observed
+// BlockDevice(s) to desired CSPC device(s)
 func (p *Planner) initNodeToDesiredCSPCDevices() error {
 	p.nodeNameToDesiredCSPCDevices = map[string][]string{}
 	for sSetUID, observedBlockDevices := range p.storageSetToObservedBlockDevices {

--- a/demo/basic/basic.yaml
+++ b/demo/basic/basic.yaml
@@ -5,7 +5,7 @@ metadata:
     namespace: openebs
 spec:
     diskConfig:
-        externalProvisioner:
+        external:
             csiAttacherName: pd.csi.storage.gke.io
             storageClassName: csi-gce-pd
     poolConfig:

--- a/types/cstorclusterconfig.go
+++ b/types/cstorclusterconfig.go
@@ -63,16 +63,25 @@ type CStorClusterConfigSpec struct {
 // DiskConfig has disk information related to
 // one cstor pool instance
 type DiskConfig struct {
-	MinCount            resource.Quantity   `json:"minCount"`
-	MinCapacity         resource.Quantity   `json:"minCapacity"`
-	ExternalProvisioner ExternalProvisioner `json:"externalProvisioner"`
+	MinCount           resource.Quantity   `json:"minCount"`
+	MinCapacity        resource.Quantity   `json:"minCapacity"`
+	ExternalDiskConfig *ExternalDiskConfig `json:"external"`
+	LocalDiskConfig    *LocalDiskConfig    `json:"local"`
 }
 
-// ExternalProvisioner has the details required to provision
-// a disk
-type ExternalProvisioner struct {
+// ExternalDiskConfig has the details required to provision
+// a disk. This makes use of CSI based volume provisioning
+// to realise a disk & subsequent disk attachment.
+type ExternalDiskConfig struct {
 	CSIAttacherName  string `json:"csiAttacherName"`
 	StorageClassName string `json:"storageClassName"`
+}
+
+// LocalDiskConfig refers to local disks details that should be
+// available & is eligible to participate in building cstor
+// pool instace.
+type LocalDiskConfig struct {
+	BlockDeviceSelector metac.ResourceSelector `json:"blockDeviceSelector"`
 }
 
 // PoolConfig defines various options to configure a

--- a/types/cstorclusterstorageset.go
+++ b/types/cstorclusterstorageset.go
@@ -34,9 +34,9 @@ type CStorClusterStorageSet struct {
 // CStorClusterStorageSetSpec has the storage details required
 // to form CStorPoolCluster's pool capacity
 type CStorClusterStorageSetSpec struct {
-	Node                CStorClusterPlanNode       `json:"node"`
-	Disk                CStorClusterStorageSetDisk `json:"disk"`
-	ExternalProvisioner ExternalProvisioner        `json:"externalProvisioner"`
+	Node               CStorClusterPlanNode       `json:"node"`
+	Disk               CStorClusterStorageSetDisk `json:"disk"`
+	ExternalDiskConfig ExternalDiskConfig         `json:"externalDiskConfig"`
 }
 
 // CStorClusterStorageSetDisk represents storage disk properties

--- a/util/string/string.go
+++ b/util/string/string.go
@@ -93,6 +93,11 @@ func (e Equality) Diff() (noops Map, additions []string, removals []string) {
 // need to be replaced as replaced from new destination
 // items. It appends new used items to the end of the resulting
 // list.
+//
+// TODO (@amitkumardas):
+//	This doesnot handle cases of
+//	1/ removal in groups
+//	2/ replacement in groups
 func (e Equality) Merge() []string {
 	var new []string
 	var used = map[string]bool{}


### PR DESCRIPTION
This commit fixes missing update to max pool count field in CStorClusterConfig. It has several Unit Tests that verifies this fix.

In addition, this commit introduces API changes to differentiate local devices from external ones. Here, external devices imply csi / cloud based disks. However, local devices imply those that are provisioned and attached to Kubernetes worker nodes. Local device(s) should be discoverable via NDM as BlockDevice(s).

closes https://github.com/mayadata-io/cstorpoolauto/issues/75

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>