### PR TITLE
fix(node plan): fix node selection logic

### DIFF
--- a/controller/cstorclusterconfig/node_test.go
+++ b/controller/cstorclusterconfig/node_test.go
@@ -17,10 +17,17 @@ limitations under the License.
 package cstorclusterconfig
 
 import (
+	"sort"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+
+	autotypes "mayadata.io/cstorpoolauto/types"
+	"mayadata.io/cstorpoolauto/unstruct"
+	metac "openebs.io/metac/apis/metacontroller/v1alpha1"
 )
 
 func TestByCreationTimeLen(t *testing.T) {
@@ -337,6 +344,307 @@ func TestByCreationTimeLess(t *testing.T) {
 	}
 }
 
+func TestSortByCreationTime(t *testing.T) {
+	var tests = map[string]struct {
+		nodes       []*unstructured.Unstructured
+		expect      []*unstructured.Unstructured
+		removeCount int
+	}{
+		"0 nodes": {
+			nodes:  []*unstructured.Unstructured{},
+			expect: []*unstructured.Unstructured{},
+		},
+		"1 nodes": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+		},
+		"3 nodes": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2020",
+							"creationTimestamp": "2020-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2010",
+							"creationTimestamp": "2010-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2010",
+							"creationTimestamp": "2010-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2020",
+							"creationTimestamp": "2020-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+		},
+		"4 nodes": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2020",
+							"creationTimestamp": "2020-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2012",
+							"creationTimestamp": "2012-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2010",
+							"creationTimestamp": "2010-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2010",
+							"creationTimestamp": "2010-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2012",
+							"creationTimestamp": "2012-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2020",
+							"creationTimestamp": "2020-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+		},
+		"3 nodes & remove = 1": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2020",
+							"creationTimestamp": "2020-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2010",
+							"creationTimestamp": "2010-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2010",
+							"creationTimestamp": "2010-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			removeCount: 1,
+		},
+		"3 nodes & remove = 2": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2020",
+							"creationTimestamp": "2020-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2010",
+							"creationTimestamp": "2010-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			removeCount: 2,
+		},
+		"3 nodes & remove = 3": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2020",
+							"creationTimestamp": "2020-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "2010",
+							"creationTimestamp": "2010-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			expect:      []*unstructured.Unstructured{},
+			removeCount: 3,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			var got []*unstructured.Unstructured
+			sort.Sort(ByCreationTime(mock.nodes))
+			actualCount := len(mock.nodes)
+			got = append(got, mock.nodes[:actualCount-mock.removeCount]...)
+
+			for idx, expectNode := range mock.expect {
+				gotNode := got[idx]
+				if expectNode.GetName() != gotNode.GetName() {
+					t.Fatalf(
+						"Expected node name %s got %s at %d",
+						expectNode.GetName(), gotNode.GetName(), idx,
+					)
+				}
+				if expectNode.GetCreationTimestamp() != gotNode.GetCreationTimestamp() {
+					t.Fatalf(
+						"Expected node creation %s got %s at %d",
+						expectNode.GetCreationTimestamp(), gotNode.GetCreationTimestamp(), idx,
+					)
+				}
+			}
+		})
+	}
+}
+
 func TestByCreationTimeSwap(t *testing.T) {
 
 }
@@ -530,5 +838,2128 @@ func TestNodeListFindByNameAndUID(t *testing.T) {
 }
 
 func TestNodeListRemoveRecentByCountFromPlannedNodes(t *testing.T) {
+	var tests = map[string]struct {
+		nodes           []*unstructured.Unstructured
+		planNodes       []autotypes.CStorClusterPlanNode
+		removeCount     int64
+		expectPlanNodes []autotypes.CStorClusterPlanNode
+		isErr           bool
+	}{
+		"node not found": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-101",
+							"uid":               "node-101",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			planNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "junk-101",
+					UID:  "junk-101",
+				},
+			},
+			isErr: true,
+		},
+		"node not found - empty list": {
+			nodes: []*unstructured.Unstructured{},
+			planNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "junk-101",
+					UID:  "junk-101",
+				},
+			},
+			isErr: true,
+		},
+		"list node 1 = plan node 1 & remove 1": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-101",
+							"uid":               "node-101",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			planNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			removeCount:     1,
+			expectPlanNodes: []autotypes.CStorClusterPlanNode{},
+			isErr:           false,
+		},
+		"list node 1 = plan node 1 & remove 0": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-101",
+							"uid":               "node-101",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			planNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			removeCount: 0,
+			expectPlanNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			isErr: false,
+		},
+		"list node 2 = plan node 1 & remove 1": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-101",
+							"uid":               "node-101",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-201",
+							"uid":               "node-201",
+							"creationTimestamp": "2006-02-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			planNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			removeCount:     1,
+			expectPlanNodes: []autotypes.CStorClusterPlanNode{},
+			isErr:           false,
+		},
+		"list node 2 = plan node 2 & remove 1": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-2006",
+							"uid":               "node-2006",
+							"creationTimestamp": "2006-01-02T15:04:05Z", // old
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-2010",
+							"uid":               "node-2010",
+							"creationTimestamp": "2010-01-02T15:04:05Z", // new
+						},
+					},
+				},
+			},
+			planNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-2006",
+					UID:  "node-2006",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-2010",
+					UID:  "node-2010",
+				},
+			},
+			removeCount: 1,
+			expectPlanNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-2006",
+					UID:  "node-2006",
+				},
+			},
+			isErr: false,
+		},
+		"list node 2 = plan node 2 & remove 2": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-101",
+							"uid":               "node-101",
+							"creationTimestamp": "2006-01-02T15:04:05Z", // old
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-201",
+							"uid":               "node-201",
+							"creationTimestamp": "2020-01-02T15:04:05Z", // new
+						},
+					},
+				},
+			},
+			planNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			removeCount:     2,
+			expectPlanNodes: []autotypes.CStorClusterPlanNode{},
+			isErr:           false,
+		},
+		"same age - list node 2 = plan node 2 & remove 1": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-101",
+							"uid":               "node-101",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-201",
+							"uid":               "node-201",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			planNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+			removeCount: 1,
+			expectPlanNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+			isErr: false,
+		},
+		"same age - list node 3 = plan node 3 & remove 2": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-101",
+							"uid":               "node-101",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-201",
+							"uid":               "node-201",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-301",
+							"uid":               "node-301",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			planNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			removeCount: 2,
+			expectPlanNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			isErr: false,
+		},
+		"same age - list node 3 = plan node 3 & remove 1": {
+			nodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-101",
+							"uid":               "node-101",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-201",
+							"uid":               "node-201",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":              "node-301",
+							"uid":               "node-301",
+							"creationTimestamp": "2006-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			planNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			removeCount: 1,
+			expectPlanNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			l := NodeList(mock.nodes)
+			got, err :=
+				l.RemoveRecentByCountFromPlannedNodes(mock.removeCount, mock.planNodes)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if mock.isErr {
+				return
+			}
+			if len(got) != len(mock.expectPlanNodes) {
+				t.Fatalf(
+					"Expected node count %d got %d", len(mock.expectPlanNodes), len(got),
+				)
+			}
+			for idx, expectNode := range mock.expectPlanNodes {
+				gotNodeName := got[idx].Name
+				gotNodeUID := got[idx].UID
+				if expectNode.Name != gotNodeName {
+					t.Fatalf(
+						"Expected name %s got %s at index %d", expectNode.Name, gotNodeName, idx)
+				}
+				if expectNode.UID != gotNodeUID {
+					t.Fatalf(
+						"Expected uid %s got %s at index %d", expectNode.UID, gotNodeUID, idx)
+				}
+			}
+		})
+	}
+}
 
+func TestNodePickByCountAndNotInPlannedNodes(t *testing.T) {
+	var tests = map[string]struct {
+		allNodes     []*unstructured.Unstructured
+		excludeNodes []autotypes.CStorClusterPlanNode
+		includeCount int64
+		expectNodes  []autotypes.CStorClusterPlanNode
+		isErr        bool
+	}{
+		"all=0 && exclude=0 && include=0": {
+			allNodes:     []*unstructured.Unstructured{},
+			excludeNodes: []autotypes.CStorClusterPlanNode{},
+			includeCount: 0,
+			isErr:        false,
+		},
+		"all=0 && exclude=0 && include=1": {
+			allNodes:     []*unstructured.Unstructured{},
+			excludeNodes: []autotypes.CStorClusterPlanNode{},
+			includeCount: 1,
+			isErr:        true,
+		},
+		"all=1 && exclude=1 && include=1": {
+			allNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+			},
+			excludeNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			includeCount: 1,
+			isErr:        true,
+		},
+		"all=1 && exclude=0 && include=1": {
+			allNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+			},
+			excludeNodes: []autotypes.CStorClusterPlanNode{},
+			includeCount: 1,
+			expectNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			isErr: false,
+		},
+		"all=2 && exclude=1 && include=1": {
+			allNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+			},
+			excludeNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			includeCount: 1,
+			expectNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+			isErr: false,
+		},
+		"all=2 && exclude=0 && include=2": {
+			allNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+			},
+			excludeNodes: []autotypes.CStorClusterPlanNode{},
+			includeCount: 2,
+			expectNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+			isErr: false,
+		},
+		"all=2 && exclude=2 && include=0": {
+			allNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+			},
+			excludeNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			includeCount: 0,
+			expectNodes:  []autotypes.CStorClusterPlanNode{},
+			isErr:        false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			l := NodeList(mock.allNodes)
+			got, err :=
+				l.PickByCountAndNotInPlannedNodes(mock.includeCount, mock.excludeNodes)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if mock.isErr {
+				return
+			}
+			if len(got) != len(mock.expectNodes) {
+				t.Fatalf(
+					"Expected node count %d got %d", len(mock.expectNodes), len(got),
+				)
+			}
+			expectNodeList := autotypes.CStorClusterPlanNodeList(mock.expectNodes)
+			for _, gotNode := range got {
+				if !expectNodeList.Contains(gotNode.Name, gotNode.UID) {
+					t.Fatalf("Node not found in expect list: [%+v]", gotNode)
+				}
+			}
+		})
+	}
+}
+
+func TestNodePickByCountAndIncludeAllPlannedNodes(t *testing.T) {
+	var tests = map[string]struct {
+		allNodes     []*unstructured.Unstructured
+		includeNodes []autotypes.CStorClusterPlanNode
+		includeCount int64
+		expectNodes  []autotypes.CStorClusterPlanNode
+		isErr        bool
+	}{
+		"nodes=1 && include=1 && count=1": {
+			allNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+			},
+			includeNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			includeCount: 1,
+			expectNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			isErr: false,
+		},
+		"nodes=0 && include=1 && count=1": {
+			allNodes: []*unstructured.Unstructured{},
+			includeNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			includeCount: 1,
+			expectNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			isErr: false,
+		},
+		"nodes=1 && include=1 && count=2": {
+			allNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+			},
+			includeNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+			includeCount: 2,
+			expectNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			isErr: false,
+		},
+		"nodes=1 && include=2 && count=2": {
+			allNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+			},
+			includeNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			includeCount: 2,
+			expectNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			isErr: false,
+		},
+		"nodes=1 && include=2 && count=3": {
+			allNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+			},
+			includeNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			includeCount: 3,
+			expectNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			isErr: false,
+		},
+		"nodes=1 && include=2 && count=1": {
+			allNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+			},
+			includeNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			includeCount: 1,
+			isErr:        true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			l := NodeList(mock.allNodes)
+			got, err :=
+				l.PickByCountAndIncludeAllPlannedNodes(mock.includeCount, mock.includeNodes)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if mock.isErr {
+				return
+			}
+			if len(got) != len(mock.expectNodes) {
+				t.Fatalf("Expected node count %d got %d", len(mock.expectNodes), len(got))
+			}
+			expectNodeList := autotypes.CStorClusterPlanNodeList(mock.expectNodes)
+			for _, gotNode := range got {
+				if !expectNodeList.Contains(gotNode.Name, gotNode.UID) {
+					t.Fatalf("Node not found in expect list: [%+v]", gotNode)
+				}
+			}
+		})
+	}
+}
+
+func TestNodePlannerGetAllNodes(t *testing.T) {
+	var tests = map[string]struct {
+		resources []*unstructured.Unstructured
+		want      []*unstructured.Unstructured
+	}{
+		"0 node of 0 resources": {
+			resources: []*unstructured.Unstructured{},
+			want:      []*unstructured.Unstructured{},
+		},
+		"0 node of 1 resources": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Pod",
+						"metadata": map[string]interface{}{
+							"name": "pod-101",
+							"uid":  "pod-101",
+						},
+					},
+				},
+			},
+			want: []*unstructured.Unstructured{},
+		},
+		"1 node of 1 resources": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+			},
+			want: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+			},
+		},
+		"1 node of 2 resources": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Pod",
+						"metadata": map[string]interface{}{
+							"name": "pod-101",
+							"uid":  "pod-101",
+						},
+					},
+				},
+			},
+			want: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+			},
+		},
+		"2 nodes of 3 resources": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Pod",
+						"metadata": map[string]interface{}{
+							"name": "pod-101",
+							"uid":  "pod-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+			},
+			want: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			p := &NodePlanner{
+				Resources: mock.resources,
+			}
+			got := p.GetAllNodes()
+			if len(got) != len(mock.want) {
+				t.Fatalf("Expected count %d got %d", len(mock.want), len(got))
+			}
+			if !unstruct.FromList(got).ContainsAll(mock.want) {
+				t.Fatalf(
+					"Expected no diff got \n%s", cmp.Diff(got, mock.want),
+				)
+			}
+		})
+	}
+}
+
+func TestNodePlannerGetAllNodeCount(t *testing.T) {
+	var tests = map[string]struct {
+		resources []*unstructured.Unstructured
+		expect    int64
+	}{
+		"0 node of 0 resources": {
+			resources: []*unstructured.Unstructured{},
+			expect:    0,
+		},
+		"0 node of 1 resources": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Pod",
+						"metadata": map[string]interface{}{
+							"name": "pod-101",
+							"uid":  "pod-101",
+						},
+					},
+				},
+			},
+			expect: 0,
+		},
+		"1 node of 1 resources": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+			},
+			expect: 1,
+		},
+		"1 node of 2 resources": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Pod",
+						"metadata": map[string]interface{}{
+							"name": "pod-101",
+							"uid":  "pod-101",
+						},
+					},
+				},
+			},
+			expect: 1,
+		},
+		"2 nodes of 3 resources": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Pod",
+						"metadata": map[string]interface{}{
+							"name": "pod-101",
+							"uid":  "pod-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+			},
+			expect: 2,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			p := &NodePlanner{
+				Resources: mock.resources,
+			}
+			got := p.GetAllNodeCount()
+			if got != mock.expect {
+				t.Fatalf("Expected count %d got %d", mock.expect, got)
+			}
+		})
+	}
+}
+
+func TestNodePlannerGetAllowedNodes(t *testing.T) {
+	var tests = map[string]struct {
+		resources    []*unstructured.Unstructured
+		nodeSelector metac.ResourceSelector
+		expect       []*unstructured.Unstructured
+		isErr        bool
+	}{
+		"0 node selector && 1 node": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+		},
+		"0 node selector && 4 nodes": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-301",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-401",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-301",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-401",
+						},
+					},
+				},
+			},
+		},
+		"matching node name selector && 1 node": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+			nodeSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"metadata.name": "node-101",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+		},
+		"matching node name selector && 2 nodes": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+						},
+					},
+				},
+			},
+			nodeSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"metadata.name": "node-101",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+		},
+		"matching node kind selector && 2 nodes": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+						},
+					},
+				},
+			},
+			nodeSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"kind": "Node",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+						},
+					},
+				},
+			},
+		},
+		"matching node kind && apiversion selector && 2 nodes": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1beta1",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+						},
+					},
+				},
+			},
+			nodeSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"kind":       "Node",
+							"apiVersion": "v1",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+		},
+		"matching node kind || apiversion selector && 2 nodes": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1beta1",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+						},
+					},
+				},
+			},
+			nodeSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"kind": "Node",
+						},
+					},
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"apiVersion": "v1",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1beta1",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+						},
+					},
+				},
+			},
+		},
+		"matching node apiVersion || name selector && 2 nodes": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1beta1",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+						},
+					},
+				},
+			},
+			nodeSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"metadata.name": "node-201",
+						},
+					},
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"apiVersion": "v1",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1beta1",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+						},
+					},
+				},
+			},
+		},
+		"matching node name selector && 1 nil node of 2 nodes": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+				nil,
+			},
+			nodeSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"metadata.name": "node-201",
+						},
+					},
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"apiVersion": "v1",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Node",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			p := &NodePlanner{
+				Resources:    mock.resources,
+				NodeSelector: mock.nodeSelector,
+			}
+			_, err := p.GetAllowedNodes()
+			got := p.allowedNodes
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if mock.isErr {
+				return
+			}
+			if !unstruct.FromList(got).ContainsAll(mock.expect) {
+				t.Fatalf("Expected no diff got \n%s", cmp.Diff(got, mock.expect))
+			}
+		})
+	}
+}
+
+func TestNodePlannerGetAllowedNodesOrCached(t *testing.T) {
+	var tests = map[string]struct {
+		cached    []*unstructured.Unstructured
+		resources []*unstructured.Unstructured
+		expect    []*unstructured.Unstructured
+		isErr     bool
+	}{
+		"cached": {
+			cached: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+			resources: []*unstructured.Unstructured{
+				nil,
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+		},
+		"no cache": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+			expect: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			p := &NodePlanner{
+				Resources:    mock.resources,
+				allowedNodes: mock.cached,
+			}
+			got, err := p.GetAllowedNodesOrCached()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if mock.isErr {
+				return
+			}
+			if !unstruct.FromList(got).ContainsAll(mock.expect) {
+				t.Fatalf("Expected no diff got:\n%s", cmp.Diff(got, mock.expect))
+			}
+		})
+	}
+}
+
+func TestNodePlannerGetAllowedNodeCountOrCached(t *testing.T) {
+	var tests = map[string]struct {
+		cached    []*unstructured.Unstructured
+		resources []*unstructured.Unstructured
+		expect    int64
+		isErr     bool
+	}{
+		"cached": {
+			cached: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+			expect: 1,
+		},
+		"no cache": {
+			resources: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+						},
+					},
+				},
+			},
+			expect: 1,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			p := &NodePlanner{
+				Resources:    mock.resources,
+				allowedNodes: mock.cached,
+			}
+			got, err := p.GetAllowedNodeCountOrCached()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if mock.isErr {
+				return
+			}
+			if got != mock.expect {
+				t.Fatalf("Expected count %d got %d", mock.expect, got)
+			}
+		})
+	}
+}
+
+func TestNodePlannerPlan(t *testing.T) {
+	var tests = map[string]struct {
+		allowedNodes  []*unstructured.Unstructured
+		observedNodes []autotypes.CStorClusterPlanNode
+		minPoolCount  resource.Quantity
+		maxPoolCount  resource.Quantity
+		expect        []autotypes.CStorClusterPlanNode
+		isErr         bool
+	}{
+		//
+		// no change
+		//
+		"allowed nodes=3 && observed=2 && min=2 && max=4": {
+			allowedNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-301",
+							"uid":  "node-301",
+						},
+					},
+				},
+			},
+			observedNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+			minPoolCount: resource.MustParse("2"),
+			maxPoolCount: resource.MustParse("4"),
+			expect: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+		},
+		//
+		// add one keep one
+		//
+		"allowed nodes=2 && observed=1 && min=2 && max=2": {
+			allowedNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+			},
+			observedNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			minPoolCount: resource.MustParse("2"),
+			maxPoolCount: resource.MustParse("2"),
+			expect: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+		},
+		//
+		// min nodes not available
+		//
+		"allowed nodes=2 && observed=1 && min=3 && max=3": {
+			allowedNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+			},
+			observedNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			minPoolCount: resource.MustParse("3"),
+			maxPoolCount: resource.MustParse("3"),
+			isErr:        true,
+		},
+		//
+		// remove one keep one
+		//
+		"allowed nodes=1 && observed=2 && min=1 && max=3": {
+			allowedNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+			},
+			observedNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+			minPoolCount: resource.MustParse("1"),
+			maxPoolCount: resource.MustParse("3"),
+			expect: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+			isErr: false,
+		},
+		//
+		// replace all nodes
+		//
+		"allowed nodes=2 && observed=1 diff && min=2 && max=3": {
+			allowedNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-301",
+							"uid":  "node-301",
+						},
+					},
+				},
+			},
+			observedNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			minPoolCount: resource.MustParse("2"),
+			maxPoolCount: resource.MustParse("3"),
+			expect: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			isErr: false,
+		},
+		//
+		// add nodes
+		//
+		"allowed nodes=5 && observed=0 diff && min=3 && max=5": {
+			allowedNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-301",
+							"uid":  "node-301",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-401",
+							"uid":  "node-401",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-501",
+							"uid":  "node-501",
+						},
+					},
+				},
+			},
+			observedNodes: []autotypes.CStorClusterPlanNode{},
+			minPoolCount:  resource.MustParse("3"),
+			maxPoolCount:  resource.MustParse("5"),
+			expect: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			isErr: false,
+		},
+		//
+		// pool instances within min & max
+		//
+		"allowed nodes=3 && observed=3 && min=2 && max=5": {
+			allowedNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-101",
+							"uid":  "node-101",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-201",
+							"uid":  "node-201",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name": "node-301",
+							"uid":  "node-301",
+						},
+					},
+				},
+			},
+			observedNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			minPoolCount: resource.MustParse("2"),
+			maxPoolCount: resource.MustParse("5"),
+			expect: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			isErr: false,
+		},
+		//
+		// reduce the pool instances
+		//
+		"allowed nodes=3 && observed=3 && creation time && min=2 && max=2": {
+			allowedNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name":              "node-101",
+							"uid":               "node-101",
+							"creationTimestamp": "2020-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name":              "node-201",
+							"uid":               "node-201",
+							"creationTimestamp": "2020-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name":              "node-301",
+							"uid":               "node-301",
+							"creationTimestamp": "2020-01-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			observedNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			minPoolCount: resource.MustParse("2"),
+			maxPoolCount: resource.MustParse("2"),
+			expect: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+			},
+			isErr: false,
+		},
+		//
+		// remove newer pool instances
+		//
+		"allowed nodes=3 && observed=3 && creation time diff && min=2 && max=2": {
+			allowedNodes: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name":              "node-101",
+							"uid":               "node-101",
+							"creationTimestamp": "2020-01-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name":              "node-201",
+							"uid":               "node-201",
+							"creationTimestamp": "2020-02-02T15:04:05Z",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Node",
+						"metadata": map[string]interface{}{
+							"name":              "node-301",
+							"uid":               "node-301",
+							"creationTimestamp": "2020-03-02T15:04:05Z",
+						},
+					},
+				},
+			},
+			observedNodes: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-301",
+					UID:  "node-301",
+				},
+			},
+			minPoolCount: resource.MustParse("2"),
+			maxPoolCount: resource.MustParse("2"),
+			expect: []autotypes.CStorClusterPlanNode{
+				autotypes.CStorClusterPlanNode{
+					Name: "node-201",
+					UID:  "node-201",
+				},
+				autotypes.CStorClusterPlanNode{
+					Name: "node-101",
+					UID:  "node-101",
+				},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			p := &NodePlanner{
+				allowedNodes: mock.allowedNodes,
+			}
+			got, err := p.Plan(NodePlannerConfig{
+				ObservedNodes: mock.observedNodes,
+				MinPoolCount:  mock.minPoolCount,
+				MaxPoolCount:  mock.maxPoolCount,
+			})
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !autotypes.CStorClusterPlanNodeList(got).ContainsAll(mock.expect) {
+				t.Fatalf("Expected no diff got:\n%s", cmp.Diff(got, mock.expect))
+			}
+		})
+	}
 }

--- a/controller/cstorclusterconfig/reconciler.go
+++ b/controller/cstorclusterconfig/reconciler.go
@@ -324,11 +324,10 @@ func (r *Reconciler) getDesiredClusterPlan(
 	plan.SetUnstructuredContent(
 		map[string]interface{}{
 			"spec": map[string]interface{}{
-				"nodes": types.MakeNodeSlice(desiredNodes),
+				"nodes": types.MakeListMapOfPlanNodes(desiredNodes),
 			},
 		},
 	)
-
 	plan.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   types.GroupDAOMayaDataIO,
 		Version: types.VersionV1Alpha1,
@@ -427,7 +426,7 @@ func (r *Reconciler) setMinPoolCountIfNotSet() error {
 	// to differentiate between a value that is not set vs.
 	// value set to 0
 	availableNodeCount := r.NodePlanner.GetAllNodeCount()
-	eligibleNodeCount, err := r.NodePlanner.GetAllowedNodeCount()
+	eligibleNodeCount, err := r.NodePlanner.GetAllowedNodeCountOrCached()
 	if err != nil {
 		return err
 	}

--- a/types/cstorclusterplan.go
+++ b/types/cstorclusterplan.go
@@ -80,17 +80,58 @@ type CStorClusterPlanStatusCondition struct {
 	LastObservedTime string         `json:"lastObservedTime"`
 }
 
-// MakeNodeSlice returns a slice of unstructured maps from
+// MakeListMapOfPlanNodes returns a slice of maps from
 // the given slice of CStorClusterPlanNode
-func MakeNodeSlice(given []CStorClusterPlanNode) []map[string]interface{} {
-	var nodeSlice []map[string]interface{}
+func MakeListMapOfPlanNodes(given []CStorClusterPlanNode) []map[string]interface{} {
+	var listMap []map[string]interface{}
 	for _, node := range given {
-		nodeSlice = append(nodeSlice,
+		listMap = append(listMap,
 			map[string]interface{}{
 				"name": node.Name,
 				"uid":  node.UID,
 			},
 		)
 	}
-	return nodeSlice
+	return listMap
+}
+
+// CStorClusterPlanNodeList is a typed representation of a list
+// of CStorClusterPlanNode(s)
+type CStorClusterPlanNodeList []CStorClusterPlanNode
+
+// CStorClusterPlanNodeNil represents a nil CStorClusterPlanNode
+var CStorClusterPlanNodeNil = CStorClusterPlanNode{}
+
+// FindByNameAndUID returns the node instance based on the
+// given name & uid
+func (l CStorClusterPlanNodeList) FindByNameAndUID(name string, uid types.UID) CStorClusterPlanNode {
+	for _, node := range l {
+		if node.Name == name && node.UID == uid {
+			return node
+		}
+	}
+	return CStorClusterPlanNodeNil
+}
+
+// Contains returns true if the given node name & uid
+// is available in this list
+func (l CStorClusterPlanNodeList) Contains(name string, uid types.UID) bool {
+	return l.FindByNameAndUID(name, uid) != CStorClusterPlanNodeNil
+}
+
+// ContainsAll returns true if the given CStorClusterPlanNode
+// list is available in this list
+func (l CStorClusterPlanNodeList) ContainsAll(given []CStorClusterPlanNode) bool {
+	if len(l) == 0 && len(l) == len(given) {
+		return true
+	}
+	if len(l) != len(given) {
+		return false
+	}
+	for _, planNode := range given {
+		if !l.Contains(planNode.Name, planNode.UID) {
+			return false
+		}
+	}
+	return true
 }

--- a/types/cstorclusterplan_test.go
+++ b/types/cstorclusterplan_test.go
@@ -64,7 +64,7 @@ func TestMakeNodeSlice(t *testing.T) {
 	}
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := MakeNodeSlice(mock.nodes)
+			got := MakeListMapOfPlanNodes(mock.nodes)
 			if len(got) != mock.expectCount {
 				t.Fatalf(
 					"Expected count %d got %d", mock.expectCount, len(got),

--- a/unstruct/unstruct_test.go
+++ b/unstruct/unstruct_test.go
@@ -110,13 +110,13 @@ func TestSelectUnstructAPIVersionANDLabels(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "apiversion-&-labels"
 			// initialize & run
-			ul := Unstruct(mock.obj)
+			ul := AsList(mock.obj)
 			eval, err := ul.WithCondition(
 				conditionName,
 				NewLazyCondition().
 					IsAPIVersion(mock.apiVersion).
 					HasLabels(mock.labels),
-			).Eval()
+			).EvalAllConditions()
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}
@@ -125,7 +125,7 @@ func TestSelectUnstructAPIVersionANDLabels(t *testing.T) {
 			}
 			// try finding
 			if err == nil {
-				got, found, err := eval.ListForCondition(conditionName)
+				got, found, err := eval.ListObjsForCondition(conditionName)
 				if mock.isErr && err == nil {
 					t.Fatalf("Expected error got none")
 				}
@@ -212,13 +212,13 @@ func TestSelectUnstructAPIVersionORKind(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "kind-or-apiversion"
 			// initialize & run
-			ul := Unstruct(mock.obj)
+			ul := AsList(mock.obj)
 			eval, err := ul.WithCondition(
 				conditionName,
 				NewLazyORCondition().
 					IsKind(mock.kind).
 					IsAPIVersion(mock.apiVersion),
-			).Eval()
+			).EvalAllConditions()
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}
@@ -227,7 +227,7 @@ func TestSelectUnstructAPIVersionORKind(t *testing.T) {
 			}
 			// try finding
 			if err == nil {
-				got, found, err := eval.ListForCondition(conditionName)
+				got, found, err := eval.ListObjsForCondition(conditionName)
 				if mock.isErr && err == nil {
 					t.Fatalf("Expected error got none")
 				}
@@ -296,11 +296,11 @@ func TestSelectUnstructKindCondition(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "my-selection-kind"
 			// initialize & run
-			ul := Unstruct(mock.obj)
+			ul := AsList(mock.obj)
 			eval, err := ul.WithCondition(
 				conditionName,
 				NewLazyCondition().IsKind(mock.kind),
-			).Eval()
+			).EvalAllConditions()
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}
@@ -309,7 +309,7 @@ func TestSelectUnstructKindCondition(t *testing.T) {
 			}
 			// try finding
 			if err == nil {
-				got, found, err := eval.ListForCondition(conditionName)
+				got, found, err := eval.ListObjsForCondition(conditionName)
 				if mock.isErr && err == nil {
 					t.Fatalf("Expected error got none")
 				}
@@ -443,9 +443,11 @@ func TestSelectRunIsKind(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "my-selection-kind"
 			// initialize & run
-			ul := UnstructList(mock.objs)
+			ul := FromList(mock.objs)
 			eval, err :=
-				ul.WithCondition(conditionName, NewLazyCondition().IsKind(mock.kind)).Eval()
+				ul.WithCondition(
+					conditionName, NewLazyCondition().IsKind(mock.kind),
+				).EvalAllConditions()
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}
@@ -454,7 +456,7 @@ func TestSelectRunIsKind(t *testing.T) {
 			}
 			// try finding
 			if err == nil {
-				got, found, err := eval.ListForCondition(conditionName)
+				got, found, err := eval.ListObjsForCondition(conditionName)
 				if mock.isErr && err == nil {
 					t.Fatalf("Expected error got none")
 				}
@@ -601,13 +603,13 @@ func TestSelectRunIsKindAndLbl(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "my-selection"
 			// initialize & run
-			ul := UnstructList(mock.objs)
+			ul := FromList(mock.objs)
 			eval, err := ul.WithCondition(
 				conditionName,
 				NewLazyCondition().
 					IsKind(mock.kind).
 					HasLabel(mock.lblKey, mock.lblValue),
-			).Eval()
+			).EvalAllConditions()
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}
@@ -616,7 +618,7 @@ func TestSelectRunIsKindAndLbl(t *testing.T) {
 			}
 			// try finding
 			if err == nil {
-				got, found, err := eval.ListForCondition(conditionName)
+				got, found, err := eval.ListObjsForCondition(conditionName)
 				if mock.isErr && err == nil {
 					t.Fatalf("Expected error got none")
 				}
@@ -629,12 +631,12 @@ func TestSelectRunIsKindAndLbl(t *testing.T) {
 				if !mock.isErr && mock.isFound != found {
 					t.Fatalf("Expected found %t got %t", mock.isFound, found)
 				}
-				if !mock.isErr && mock.failCount != len(eval.Rejects()) {
-					failMsgs, _ := eval.FailureReasons()
+				if !mock.isErr && mock.failCount != len(eval.ListAllConditionRejects()) {
+					failMsgs, _ := eval.ListAllConditionFailures()
 					t.Fatalf(
 						"Expected rejects %d got %d: Rejects [%#v]",
 						mock.failCount,
-						len(eval.Rejects()),
+						len(eval.ListAllConditionRejects()),
 						failMsgs,
 					)
 				}
@@ -761,13 +763,13 @@ func TestSelectRunIsAPIVersionAndAnn(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "my-selection"
 			// initialize & run
-			ul := UnstructList(mock.objs)
+			ul := FromList(mock.objs)
 			eval, err := ul.WithCondition(
 				conditionName,
 				NewLazyCondition().
 					IsAPIVersion(mock.apiVersion).
 					HasAnn(mock.annKey, mock.annValue),
-			).Eval()
+			).EvalAllConditions()
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}
@@ -776,7 +778,7 @@ func TestSelectRunIsAPIVersionAndAnn(t *testing.T) {
 			}
 			// try finding
 			if err == nil {
-				got, found, err := eval.ListForCondition(conditionName)
+				got, found, err := eval.ListObjsForCondition(conditionName)
 				if mock.isErr && err == nil {
 					t.Fatalf("Expected error got none")
 				}
@@ -789,12 +791,12 @@ func TestSelectRunIsAPIVersionAndAnn(t *testing.T) {
 				if !mock.isErr && mock.isFound != found {
 					t.Fatalf("Expected found %t got %t", mock.isFound, found)
 				}
-				if !mock.isErr && mock.failCount != len(eval.Rejects()) {
-					failMsgs, _ := eval.FailureReasons()
+				if !mock.isErr && mock.failCount != len(eval.ListAllConditionRejects()) {
+					failMsgs, _ := eval.ListAllConditionFailures()
 					t.Fatalf(
 						"Expected rejects %d got %d: Rejects [%#v]",
 						mock.failCount,
-						len(eval.Rejects()),
+						len(eval.ListAllConditionRejects()),
 						failMsgs,
 					)
 				}
@@ -899,10 +901,10 @@ func TestSelectRunCategorizeIsKindAndAPIVersion(t *testing.T) {
 			conditionOne := "apiversion-cond"
 			conditionTwo := "kind-cond"
 			// initialize & run
-			ul := UnstructList(mock.objs)
+			ul := FromList(mock.objs)
 			ul.WithCondition(conditionOne, NewLazyCondition().IsAPIVersion(mock.apiVersion))
 			ul.WithCondition(conditionTwo, NewLazyCondition().IsKind(mock.kind))
-			eval, err := ul.Eval()
+			eval, err := ul.EvalAllConditions()
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}
@@ -912,7 +914,7 @@ func TestSelectRunCategorizeIsKindAndAPIVersion(t *testing.T) {
 			// try finding
 			if err == nil {
 				// first condition
-				got, found, err := eval.ListForCondition(conditionOne)
+				got, found, err := eval.ListObjsForCondition(conditionOne)
 				if mock.isErr && err == nil {
 					t.Fatalf("Cond-1: Expected error got none")
 				}
@@ -929,7 +931,7 @@ func TestSelectRunCategorizeIsKindAndAPIVersion(t *testing.T) {
 				}
 
 				// second condition
-				got, found, err = eval.ListForCondition(conditionTwo)
+				got, found, err = eval.ListObjsForCondition(conditionTwo)
 				if mock.isErr && err == nil {
 					t.Fatalf("Cond-2: Expected error got none")
 				}
@@ -1034,7 +1036,7 @@ func TestSelectRunConditionalOR(t *testing.T) {
 			andCondition := "and-cond"
 			orCondition := "or-cond"
 			// initialize & run
-			ul := UnstructList(mock.objs)
+			ul := FromList(mock.objs)
 			ul.WithCondition(
 				andCondition,
 				NewLazyCondition().
@@ -1047,7 +1049,7 @@ func TestSelectRunConditionalOR(t *testing.T) {
 					HasAnns(mock.anns).
 					HasLabels(mock.lbls),
 			)
-			eval, err := ul.Eval()
+			eval, err := ul.EvalAllConditions()
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}
@@ -1057,7 +1059,7 @@ func TestSelectRunConditionalOR(t *testing.T) {
 			// try finding
 			if err == nil {
 				// first condition
-				got, found, err := eval.ListForCondition(andCondition)
+				got, found, err := eval.ListObjsForCondition(andCondition)
 				if mock.isErr && err == nil {
 					t.Fatalf("Cond-1: Expected error got none")
 				}
@@ -1074,7 +1076,7 @@ func TestSelectRunConditionalOR(t *testing.T) {
 				}
 
 				// second condition
-				got, found, err = eval.ListForCondition(orCondition)
+				got, found, err = eval.ListObjsForCondition(orCondition)
 				if mock.isErr && err == nil {
 					t.Fatalf("Cond-2: Expected error got none")
 				}


### PR DESCRIPTION
This commits fixes node selection logic used to create CStorClusterPlan resource. Unit tests have been implemented to verify the same.

In addition, there are a few name changes done to unstruct package to make it more readable.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>