### PR TITLE
fix(merge): fix diff between observed and desired nodes

### DIFF
--- a/controller/cstorclusterconfig/reconciler.go
+++ b/controller/cstorclusterconfig/reconciler.go
@@ -329,8 +329,8 @@ func (r *Reconciler) getDesiredClusterPlan(
 		},
 	)
 	plan.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   types.GroupDAOMayaDataIO,
-		Version: types.VersionV1Alpha1,
+		Group:   string(types.GroupDAOMayaDataIO),
+		Version: string(types.VersionV1Alpha1),
 		Kind:    string(types.KindCStorClusterPlan),
 	})
 	// name & namespace are same as CStorClusterConfig
@@ -384,14 +384,14 @@ func (r *Reconciler) getDesiredClusterConfig() *unstructured.Unstructured {
 					"minCount":    r.minDiskCount,
 				},
 				"poolConfig": map[string]interface{}{
-					"raidType": r.poolRAIDType,
+					"raidType": string(r.poolRAIDType),
 				},
 			},
 		},
 	)
 	config.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   types.GroupDAOMayaDataIO,
-		Version: types.VersionV1Alpha1,
+		Group:   string(types.GroupDAOMayaDataIO),
+		Version: string(types.VersionV1Alpha1),
 		Kind:    string(types.KindCStorClusterConfig),
 	})
 	// name & namespace are same as CStorClusterConfig

--- a/demo/basic/cstor-operator.yaml
+++ b/demo/basic/cstor-operator.yaml
@@ -60,6 +60,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+        # Where OpenEBS can store required files. Default base path will be /var/openebs
+        # - name: OPENEBS_IO_BASE_DIR
+        #   value: "/var/openebs"
         # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
         # to be used for saving the shared content between the side cars
         # of cstor pool pod. This ENV is also used to indicate the location
@@ -106,6 +110,10 @@ spec:
         imagePullPolicy: IfNotPresent
         image: quay.io/openebs/cvc-operator:ci
         env:
+        # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+        # Where OpenEBS can store required files. Default base path will be /var/openebs
+        # - name: OPENEBS_IO_BASE_DIR
+        #   value: "/var/openebs"
         # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
         # that to be used for saving the core dump of cstor volume pod.
         # The default path used is /var/openebs/sparse

--- a/demo/basic/test.sh
+++ b/demo/basic/test.sh
@@ -14,6 +14,7 @@ cleanup() {
   kubectl delete -f ../../deploy/operator.yaml || true
   kubectl delete -f ../../deploy/rbac.yaml || true
   kubectl delete -f ../../deploy/crd.yaml || true
+  kubectl delete configmap config-test -n openebs || true
 
   kubectl delete -f storage_crd.yaml || true
   kubectl delete -f storage_rbac.yaml || true
@@ -39,6 +40,7 @@ echo -e "\n++ Installing cstorpoolauto operator"
 kubectl apply -f ../../deploy/namespace.yaml
 kubectl apply -f ../../deploy/crd.yaml
 kubectl apply -f ../../deploy/rbac.yaml
+kubectl apply configmap config-test -n openebs --from-file=../../deploy/config.yaml
 kubectl apply -f ../../deploy/operator.yaml
 echo -e "\n++ Installed cstorpoolauto operator successfully"
 

--- a/deploy/config.yaml
+++ b/deploy/config.yaml
@@ -1,0 +1,25 @@
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  name: sync-cstorclusterconfig
+  namespace: cstorpoolauto
+spec:
+  updateAny: true
+  watch:
+    apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterconfigs
+  attachments:
+  - apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterplans
+    updateStrategy:
+      method: InPlace
+  - apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterconfigs
+    updateStrategy:
+      method: InPlace
+  - apiVersion: v1
+    resource: nodes
+  hooks:
+    sync:
+      inline:
+        funcName: sync/cstorclusterconfig

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -26,7 +26,14 @@ spec:
         args:
         - --logtostderr
         - --run-as-local
-        - -v=4
+        - -v=5
         - --discovery-interval=40s
         - --cache-flush-interval=240s
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config/metac
+      volumes:
+      - name: config
+        configMap:
+          name: config-test
 ---

--- a/types/cstorclusterplan.go
+++ b/types/cstorclusterplan.go
@@ -82,13 +82,13 @@ type CStorClusterPlanStatusCondition struct {
 
 // MakeListMapOfPlanNodes returns a slice of maps from
 // the given slice of CStorClusterPlanNode
-func MakeListMapOfPlanNodes(given []CStorClusterPlanNode) []map[string]interface{} {
-	var listMap []map[string]interface{}
+func MakeListMapOfPlanNodes(given []CStorClusterPlanNode) []interface{} {
+	var listMap []interface{}
 	for _, node := range given {
 		listMap = append(listMap,
 			map[string]interface{}{
 				"name": node.Name,
-				"uid":  node.UID,
+				"uid":  string(node.UID),
 			},
 		)
 	}


### PR DESCRIPTION
This commit fixes the difference between observed and desired specification of CStorClusterPlan's spec.nodes field. This should avoid the cases where spec.nodes got nullified. Various unit tests have been added to verify the fix.

_NOTE: However, this test requires integration test or e2e test to verify & close the error._

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>