### PR TITLE
chore(rename): update names of various metacontrollers

### DIFF
--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -1,8 +1,8 @@
 apiVersion: metac.openebs.io/v1alpha1
 kind: GenericController
 metadata:
-  name: sync-cstorclusterconfig
-  namespace: cstorpoolauto
+  name: sync-config
+  namespace: cspauto
 spec:
   updateAny: true
   watch:
@@ -27,8 +27,8 @@ spec:
 apiVersion: metac.openebs.io/v1alpha1
 kind: GenericController
 metadata:
-  name: sync-cstorclusterplan
-  namespace: cstorpoolauto
+  name: sync-plan
+  namespace: cspauto
 spec:
   watch:
     apiVersion: dao.mayadata.io/v1alpha1
@@ -48,8 +48,8 @@ spec:
 apiVersion: metac.openebs.io/v1alpha1
 kind: GenericController
 metadata:
-  name: sync-cstorclusterstorageset
-  namespace: cstorpoolauto
+  name: sync-storageset
+  namespace: cspauto
 spec:
   watch:
     apiVersion: dao.mayadata.io/v1alpha1
@@ -68,7 +68,7 @@ apiVersion: metac.openebs.io/v1alpha1
 kind: GenericController
 metadata:
   name: sync-blockdevice
-  namespace: cstorpoolauto
+  namespace: cspauto
 spec:
   updateAny: true
   watch:
@@ -91,8 +91,8 @@ spec:
 apiVersion: metac.openebs.io/v1alpha1
 kind: GenericController
 metadata:
-  name: sync-cstorpoolcluster
-  namespace: cstorpoolauto
+  name: sync-cspc
+  namespace: cspauto
 spec:
   watch:
     apiVersion: dao.mayadata.io/v1alpha1

--- a/demo/basic/test.sh
+++ b/demo/basic/test.sh
@@ -40,7 +40,7 @@ echo -e "\n++ Installing cstorpoolauto operator"
 kubectl apply -f ../../deploy/namespace.yaml
 kubectl apply -f ../../deploy/crd.yaml
 kubectl apply -f ../../deploy/rbac.yaml
-kubectl apply configmap config-test -n openebs --from-file=../../deploy/config.yaml
+kubectl create configmap config-test -n openebs --from-file="../../deploy/config.yaml"
 kubectl apply -f ../../deploy/operator.yaml
 echo -e "\n++ Installed cstorpoolauto operator successfully"
 

--- a/deploy/config.yaml
+++ b/deploy/config.yaml
@@ -1,8 +1,8 @@
 apiVersion: metac.openebs.io/v1alpha1
 kind: GenericController
 metadata:
-  name: sync-cstorclusterconfig
-  namespace: cstorpoolauto
+  name: sync-config
+  namespace: cspauto
 spec:
   updateAny: true
   watch:
@@ -23,3 +23,93 @@ spec:
     sync:
       inline:
         funcName: sync/cstorclusterconfig
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  name: sync-plan
+  namespace: cspauto
+spec:
+  watch:
+    apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterplans
+  attachments:
+  - apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterstoragesets
+    updateStrategy:
+      method: InPlace
+  - apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterconfigs
+  hooks:
+    sync:
+      inline:
+        funcName: sync/cstorclusterplan
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  name: sync-storageset
+  namespace: cspauto
+spec:
+  watch:
+    apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterstoragesets
+  attachments:
+  - apiVersion: dao.mayadata.io/v1alpha1
+    resource: storages
+    updateStrategy:
+      method: InPlace
+  hooks:
+    sync:
+      inline:
+        funcName: sync/cstorclusterstorageset
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  name: sync-blockdevice
+  namespace: cspauto
+spec:
+  updateAny: true
+  watch:
+    apiVersion: dao.mayadata.io/v1alpha1
+    resource: storages
+  attachments:
+  - apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterstoragesets
+  - apiVersion: openebs.io/v1alpha1
+    resource: blockdevices
+    updateStrategy:
+      method: InPlace
+  - apiVersion: v1
+    resource: persistentvolumeclaims
+  hooks:
+    sync:
+      inline:
+        funcName: sync/blockdevice
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  name: sync-cspc
+  namespace: cspauto
+spec:
+  watch:
+    apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterplans
+  attachments:
+  - apiVersion: openebs.io/v1alpha1
+    resource: cstorpoolclusters
+    updateStrategy:
+      method: InPlace
+  - apiVersion: openebs.io/v1alpha1
+    resource: blockdevices
+  - apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterstoragesets
+  - apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterconfigs
+  hooks:
+    sync:
+      inline:
+        funcName: sync/cstorpoolcluster
+---


### PR DESCRIPTION
This commit updates the names of metacontrollers to be short and precise. In addition, the deploy/config.yaml is made to be same as config/metac.yaml.

NOTE: deploy/config.yaml is used for testing purposes only.
NOTE: cstorpoolauto binary will always have the appropriate config file i.e. metac.yaml

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>