### PR TITLE
feat(selector): introduce selector for unstruct instances

### DIFF
--- a/controller/cstorclusterconfig/node_test.go
+++ b/controller/cstorclusterconfig/node_test.go
@@ -1761,7 +1761,7 @@ func TestNodePlannerGetAllNodes(t *testing.T) {
 			if len(got) != len(mock.want) {
 				t.Fatalf("Expected count %d got %d", len(mock.want), len(got))
 			}
-			if !unstruct.FromList(got).ContainsAll(mock.want) {
+			if !unstruct.NewListing(got).ContainsAll(mock.want) {
 				t.Fatalf(
 					"Expected no diff got \n%s", cmp.Diff(got, mock.want),
 				)
@@ -2308,7 +2308,7 @@ func TestNodePlannerGetAllowedNodes(t *testing.T) {
 			if mock.isErr {
 				return
 			}
-			if !unstruct.FromList(got).ContainsAll(mock.expect) {
+			if !unstruct.NewListing(got).ContainsAll(mock.expect) {
 				t.Fatalf("Expected no diff got \n%s", cmp.Diff(got, mock.expect))
 			}
 		})
@@ -2388,7 +2388,7 @@ func TestNodePlannerGetAllowedNodesOrCached(t *testing.T) {
 			if mock.isErr {
 				return
 			}
-			if !unstruct.FromList(got).ContainsAll(mock.expect) {
+			if !unstruct.NewListing(got).ContainsAll(mock.expect) {
 				t.Fatalf("Expected no diff got:\n%s", cmp.Diff(got, mock.expect))
 			}
 		})

--- a/unstruct/list.go
+++ b/unstruct/list.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstruct
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+// List is a custom datatype representing a list of
+// unstructured instances
+type List []*unstructured.Unstructured
+
+// Contains returns true if provided name && uid is
+// is available in this List.
+func (s List) Contains(target *unstructured.Unstructured) bool {
+	if target == nil {
+		// we don't know how to compare against a nil
+		return false
+	}
+	for _, obj := range s {
+		if obj.GetName() == target.GetName() &&
+			obj.GetNamespace() == target.GetNamespace() &&
+			obj.GetKind() == target.GetKind() &&
+			obj.GetAPIVersion() == target.GetAPIVersion() {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsAll returns true if each item in the provided targets
+// is available in this List.
+func (s List) ContainsAll(targets []*unstructured.Unstructured) bool {
+	if len(s) < len(targets) || len(targets) == 0 {
+		// we donot know how to handle nil target list
+		return false
+	}
+	for _, t := range targets {
+		if !s.Contains(t) {
+			// return false if any item does not match
+			return false
+		}
+	}
+	return true
+}

--- a/unstruct/selector.go
+++ b/unstruct/selector.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstruct
+
+import (
+	"reflect"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metac "openebs.io/metac/apis/metacontroller/v1alpha1"
+	"openebs.io/metac/controller/common/selector"
+	"openebs.io/metac/dynamic/apply"
+)
+
+// Selection provides select & match capabilities to unstructured
+type Selection struct {
+	Object           *unstructured.Unstructured
+	ResourceSelector metac.ResourceSelector
+}
+
+// Selector returns a new instance of Selection
+func Selector(terms metac.ResourceSelector, obj *unstructured.Unstructured) *Selection {
+	return &Selection{
+		Object:           obj,
+		ResourceSelector: terms,
+	}
+}
+
+// IsMatchOrError returns true if selection terms matches with
+// its object
+func (s *Selection) IsMatchOrError() (bool, error) {
+	eval := selector.Evaluation{
+		Target: s.Object,
+		Terms:  s.ResourceSelector.SelectorTerms,
+	}
+	return eval.RunMatch()
+}
+
+// IsMatch returns true if selection terms matches with
+// its object
+func (s *Selection) IsMatch() bool {
+	match, _ := s.IsMatchOrError()
+	return match
+}
+
+// ListSelection provides select & match capabilities to list of
+// unstructured instances
+type ListSelection struct {
+	// list of instances against which selector terms get applied
+	Objects []*unstructured.Unstructured
+
+	// selector terms that are applied against the list of objects
+	ResourceSelector metac.ResourceSelector
+
+	// flag when set to true will not consider cached results
+	DisableCache bool
+
+	// matches & nomatches represent the cached copies of objects
+	// that matched & did not match _(against the selector terms)_
+	// correspondingly
+	matches   []*unstructured.Unstructured
+	nomatches []*unstructured.Unstructured
+}
+
+// ListSelector returns a new instance of ListSelection
+func ListSelector(
+	terms metac.ResourceSelector, objs ...*unstructured.Unstructured,
+) *ListSelection {
+	s := &ListSelection{
+		ResourceSelector: terms,
+	}
+	for _, obj := range objs {
+		if obj == nil || obj.UnstructuredContent() == nil {
+			// accept only non nil instances
+			continue
+		}
+		s.Objects = append(s.Objects, obj)
+	}
+	return s
+}
+
+// List returns the matches & no-matches
+func (s *ListSelection) List() (matches, nomatches []*unstructured.Unstructured) {
+	for _, obj := range s.Objects {
+		sr := Selector(s.ResourceSelector, obj)
+		if sr.IsMatch() {
+			matches = append(matches, obj)
+		} else {
+			nomatches = append(nomatches, obj)
+		}
+	}
+	return
+}
+
+// ListOrCached returns the cached matches & no-matches if present
+// or runs the selector against its objects
+func (s *ListSelection) ListOrCached() (matches, nomatches []*unstructured.Unstructured) {
+	if !s.DisableCache && (len(s.matches) != 0 || len(s.nomatches) != 0) {
+		// selector was run earlier, return the cached matches
+		return s.matches, s.nomatches
+	}
+	s.matches, s.nomatches = s.List()
+	return s.matches, s.nomatches
+}
+
+// MatchContains returns true if all the provided instance
+// is a successful match
+func (s *ListSelection) MatchContains(target *unstructured.Unstructured) bool {
+	matches, _ := s.ListOrCached()
+	l := List(matches)
+	return l.Contains(target)
+}
+
+// NoMatchContains returns true if all the provided instance
+// is not a successful match
+func (s *ListSelection) NoMatchContains(target *unstructured.Unstructured) bool {
+	_, nomatches := s.ListOrCached()
+	l := List(nomatches)
+	return l.Contains(target)
+}
+
+// MatchContainsAll returns true if all the provided instances
+// are successful matches
+func (s *ListSelection) MatchContainsAll(targets []*unstructured.Unstructured) bool {
+	matches, _ := s.ListOrCached()
+	l := List(matches)
+	return l.ContainsAll(targets)
+}
+
+// NoMatchContainsAll returns true if all the provided instances
+// are not successful matches
+func (s *ListSelection) NoMatchContainsAll(targets []*unstructured.Unstructured) bool {
+	_, nomatches := s.ListOrCached()
+	l := List(nomatches)
+	return l.ContainsAll(targets)
+}
+
+// MatchCount returns true if number of successful matches
+// equals the provided count
+func (s *ListSelection) MatchCount(target int) bool {
+	matches, _ := s.ListOrCached()
+	return len(matches) == target
+}
+
+// NoMatchCount returns true if number of un-successful matches
+// equals the provided count
+func (s *ListSelection) NoMatchCount(target int) bool {
+	_, nomatches := s.ListOrCached()
+	return len(nomatches) == target
+}
+
+// mergeByDesired executes a 3 way merge operation by
+// merging the observed state with desired state. Last
+// applied state is considered same as desired state.
+func mergeByDesired(observed, desired *unstructured.Unstructured) (map[string]interface{}, error) {
+	return apply.Merge(
+		observed.UnstructuredContent(), // observed
+		desired.UnstructuredContent(),  // last applied
+		desired.UnstructuredContent(),  // desired
+	)
+}
+
+// MatchDesiredOrError returns true if provided instance
+// is contained & its desired state matches.
+//
+// NOTE:
+//	Here desired state equality is performed. One just
+// needs to provide the section from the entire structure
+// that will be used to match.
+func (s *ListSelection) MatchDesiredOrError(desired *unstructured.Unstructured) (bool, error) {
+	if desired == nil || desired.UnstructuredContent() == nil {
+		return false, errors.Errorf("Can't match target against list: Nil target")
+	}
+	matches, _ := s.ListOrCached()
+	for _, observedMatch := range matches {
+		if observedMatch.GetName() == desired.GetName() &&
+			observedMatch.GetNamespace() == desired.GetNamespace() &&
+			observedMatch.GetKind() == desired.GetKind() &&
+			observedMatch.GetAPIVersion() == desired.GetAPIVersion() {
+			merged, err := mergeByDesired(observedMatch, desired)
+			if err != nil {
+				return false, err
+			}
+			if !reflect.DeepEqual(merged, observedMatch.UnstructuredContent()) {
+				return false, nil
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// MatchDesired returns true if provided instance match
+// the selection & its desired state matches.
+//
+// NOTE:
+//	Here desired state equality is performed. One just
+// needs to provide the section from the entire structure
+// that will be used to match.
+func (s *ListSelection) MatchDesired(desired *unstructured.Unstructured) bool {
+	ismatch, err := s.MatchDesiredOrError(desired)
+	if err != nil {
+		// we swallow the error & return false
+		return false
+	}
+	return ismatch
+}
+
+// MatchDesiredAll returns true if all provided instances match
+// the selection && are equal as well.
+func (s *ListSelection) MatchDesiredAll(desired []*unstructured.Unstructured) bool {
+	if len(desired) == 0 {
+		// we dont match nil list
+		return false
+	}
+	for _, desiredState := range desired {
+		ismatch := s.MatchDesired(desiredState)
+		if !ismatch {
+			// a single nomatch fails this logic
+			return false
+		}
+	}
+	return true
+}

--- a/unstruct/selector_test.go
+++ b/unstruct/selector_test.go
@@ -1,0 +1,543 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstruct
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metac "openebs.io/metac/apis/metacontroller/v1alpha1"
+)
+
+func TestListSelectionMatchContains(t *testing.T) {
+	var tests = map[string]struct {
+		selector metac.ResourceSelector
+		items    []*unstructured.Unstructured
+		target   *unstructured.Unstructured
+		isFound  bool
+	}{
+		"finalizer selector": {
+			selector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchSlice: map[string][]string{
+							"metadata.finalizers": []string{
+								"a-protect",
+								"b-protect",
+							},
+						},
+					},
+				},
+			},
+			items: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"kind": "Service",
+							"name": "my-service",
+							"finalizers": []interface{}{
+								"a-protect",
+								"b-protect",
+							},
+						},
+					},
+				},
+			},
+			target: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"kind": "Service",
+						"name": "my-service",
+					},
+				},
+			},
+			isFound: false, // fix bug in metac
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			s := ListSelector(mock.selector, mock.items...)
+			got := s.MatchContains(mock.target)
+			if got != mock.isFound {
+				t.Fatalf("Expected %t got %t: matches %d", mock.isFound, got, len(s.matches))
+			}
+		})
+	}
+}
+
+func TestListSelectionMergeByDesired(t *testing.T) {
+	var tests = map[string]struct {
+		observed *unstructured.Unstructured
+		desired  *unstructured.Unstructured
+		want     map[string]interface{}
+		isErr    bool
+	}{
+		"observed == desired : kind matches => observed == want": {
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Pod",
+				},
+			},
+			want: map[string]interface{}{
+				"kind":       "Pod",
+				"apiVersion": "v1",
+			},
+			isErr: false,
+		},
+		"observed != desired : kind nomatch: Pod to Service": {
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Service",
+				},
+			},
+			want: map[string]interface{}{
+				"kind":       "Service",
+				"apiVersion": "v1",
+			},
+			isErr: false,
+		},
+		"observed == desired : kind & apiVersion matches => observed == want": {
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"name": "Hello",
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+				},
+			},
+			want: map[string]interface{}{
+				"kind":       "Pod",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"name": "Hello",
+				},
+			},
+			isErr: false,
+		},
+		"observed != desired : finalizer nomatch : desired finalizers": {
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"finalizers": []interface{}{
+							"a-protect",
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"finalizers": []interface{}{
+							"a-protect",
+							"b-protect",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"kind":       "Pod",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"finalizers": []interface{}{
+						"a-protect",
+						"b-protect",
+					},
+				},
+			},
+			isErr: false,
+		},
+		"observed != desired : finalizer nomatch : empty finalizers": {
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"finalizers": []interface{}{
+							"a-protect",
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"finalizers": []interface{}{},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"kind":       "Pod",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"finalizers": []interface{}{},
+				},
+			},
+			isErr: false,
+		},
+		"observed != desired : missing finalizer => observed == want": {
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"finalizers": []interface{}{
+							"a-protect",
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata":   map[string]interface{}{},
+				},
+			},
+			want: map[string]interface{}{
+				"kind":       "Pod",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"finalizers": []interface{}{
+						"a-protect",
+					},
+				},
+			},
+			isErr: false,
+		},
+		"observed != desired : missing labels : => observed == want": {
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "kool",
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata":   map[string]interface{}{},
+				},
+			},
+			want: map[string]interface{}{
+				"kind":       "Pod",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"app": "kool",
+					},
+				},
+			},
+			isErr: false,
+		},
+		"observed != desired : missing annotations : => observed == want": {
+			observed: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"app": "kool",
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Pod",
+					"apiVersion": "v1",
+					"metadata":   map[string]interface{}{},
+				},
+			},
+			want: map[string]interface{}{
+				"kind":       "Pod",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"app": "kool",
+					},
+				},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			merged, err := mergeByDesired(mock.observed, mock.desired)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !reflect.DeepEqual(merged, mock.want) {
+				t.Fatalf("merged != want:\n%s", cmp.Diff(merged, mock.want))
+			}
+		})
+	}
+}
+
+func TestListSelectionMatchDesired(t *testing.T) {
+	var tests = map[string]struct {
+		selector       metac.ResourceSelector
+		observedObjs   []*unstructured.Unstructured
+		desired        *unstructured.Unstructured
+		isDesiredMatch bool
+	}{
+		"labels selector => merged == observed": {
+			selector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchLabels: map[string]string{
+							"app": "kool",
+						},
+					},
+				},
+			},
+			observedObjs: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Pod",
+						"metadata": map[string]interface{}{
+							"name": "my-pod",
+							"labels": map[string]interface{}{
+								"app": "kool",
+							},
+							"finalizers": []interface{}{
+								"a-protect",
+								"b-protect",
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Pod",
+					"metadata": map[string]interface{}{
+						"name": "my-pod",
+					},
+				},
+			},
+			isDesiredMatch: true,
+		},
+		"finalizer selector => merged == observed": {
+			selector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchSlice: map[string][]string{
+							"metadata.finalizers": []string{
+								"a-protect",
+								"b-protect",
+							},
+						},
+					},
+				},
+			},
+			observedObjs: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Pod",
+						"metadata": map[string]interface{}{
+							"name": "my-pod",
+							"labels": map[string]interface{}{
+								"app": "kool",
+							},
+							"finalizers": []interface{}{
+								"a-protect",
+								"b-protect",
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Pod",
+					"metadata": map[string]interface{}{
+						"name": "my-pod",
+					},
+				},
+			},
+			isDesiredMatch: false, // fix bug in metac
+		},
+		"labels selector => merged != observed": {
+			selector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchLabels: map[string]string{
+							"app": "kool",
+						},
+					},
+				},
+			},
+			observedObjs: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Pod",
+						"metadata": map[string]interface{}{
+							"name": "my-pod",
+							"labels": map[string]interface{}{
+								"app": "kool",
+							},
+							"finalizers": []interface{}{
+								"a-protect",
+								"b-protect",
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Pod",
+					"metadata": map[string]interface{}{
+						"name": "my-pod",
+					},
+					"labels": map[string]interface{}{
+						"app":  "kool",
+						"more": "stuff", // extra
+					},
+				},
+			},
+			isDesiredMatch: false,
+		},
+		"kind & name selector : observed has extra labels & anns => merged == observed": {
+			selector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"kind":          "Pod",
+							"metadata.name": "my-pod",
+						},
+					},
+				},
+			},
+			observedObjs: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Pod",
+						"metadata": map[string]interface{}{
+							"name": "my-pod",
+							"labels": map[string]interface{}{
+								"app": "kool",
+							},
+							"annotations": map[string]interface{}{
+								"name": "kool",
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Pod",
+					"metadata": map[string]interface{}{
+						"name": "my-pod",
+					},
+				},
+			},
+			isDesiredMatch: true,
+		},
+		"kind & name selector : observed has extra anns => merged == observed": {
+			selector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchFields: map[string]string{
+							"kind":          "Pod",
+							"metadata.name": "my-pod",
+						},
+					},
+				},
+			},
+			observedObjs: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Pod",
+						"metadata": map[string]interface{}{
+							"name": "my-pod",
+							"labels": map[string]interface{}{
+								"app": "kool",
+							},
+							"annotations": map[string]interface{}{
+								"name": "kool",
+							},
+						},
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Pod",
+					"metadata": map[string]interface{}{
+						"name": "my-pod",
+						"labels": map[string]interface{}{
+							"app": "kool",
+						},
+					},
+				},
+			},
+			isDesiredMatch: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			s := ListSelector(mock.selector, mock.observedObjs...)
+			got := s.MatchDesired(mock.desired)
+			if got != mock.isDesiredMatch {
+				t.Fatalf("Expected %t got %t", mock.isDesiredMatch, got)
+			}
+		})
+	}
+}

--- a/unstruct/unstruct_test.go
+++ b/unstruct/unstruct_test.go
@@ -110,7 +110,7 @@ func TestSelectUnstructAPIVersionANDLabels(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "apiversion-&-labels"
 			// initialize & run
-			ul := AsList(mock.obj)
+			ul := AsListing(mock.obj)
 			eval, err := ul.WithCondition(
 				conditionName,
 				NewLazyCondition().
@@ -212,7 +212,7 @@ func TestSelectUnstructAPIVersionORKind(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "kind-or-apiversion"
 			// initialize & run
-			ul := AsList(mock.obj)
+			ul := AsListing(mock.obj)
 			eval, err := ul.WithCondition(
 				conditionName,
 				NewLazyORCondition().
@@ -296,7 +296,7 @@ func TestSelectUnstructKindCondition(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "my-selection-kind"
 			// initialize & run
-			ul := AsList(mock.obj)
+			ul := AsListing(mock.obj)
 			eval, err := ul.WithCondition(
 				conditionName,
 				NewLazyCondition().IsKind(mock.kind),
@@ -443,7 +443,7 @@ func TestSelectRunIsKind(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "my-selection-kind"
 			// initialize & run
-			ul := FromList(mock.objs)
+			ul := NewListing(mock.objs)
 			eval, err :=
 				ul.WithCondition(
 					conditionName, NewLazyCondition().IsKind(mock.kind),
@@ -603,7 +603,7 @@ func TestSelectRunIsKindAndLbl(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "my-selection"
 			// initialize & run
-			ul := FromList(mock.objs)
+			ul := NewListing(mock.objs)
 			eval, err := ul.WithCondition(
 				conditionName,
 				NewLazyCondition().
@@ -763,7 +763,7 @@ func TestSelectRunIsAPIVersionAndAnn(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			conditionName := "my-selection"
 			// initialize & run
-			ul := FromList(mock.objs)
+			ul := NewListing(mock.objs)
 			eval, err := ul.WithCondition(
 				conditionName,
 				NewLazyCondition().
@@ -901,7 +901,7 @@ func TestSelectRunCategorizeIsKindAndAPIVersion(t *testing.T) {
 			conditionOne := "apiversion-cond"
 			conditionTwo := "kind-cond"
 			// initialize & run
-			ul := FromList(mock.objs)
+			ul := NewListing(mock.objs)
 			ul.WithCondition(conditionOne, NewLazyCondition().IsAPIVersion(mock.apiVersion))
 			ul.WithCondition(conditionTwo, NewLazyCondition().IsKind(mock.kind))
 			eval, err := ul.EvalAllConditions()
@@ -1036,7 +1036,7 @@ func TestSelectRunConditionalOR(t *testing.T) {
 			andCondition := "and-cond"
 			orCondition := "or-cond"
 			// initialize & run
-			ul := FromList(mock.objs)
+			ul := NewListing(mock.objs)
 			ul.WithCondition(
 				andCondition,
 				NewLazyCondition().


### PR DESCRIPTION
This commit makes use of metac's ResourceSelector to filter one or more unstructured instances. Selector can replace the conditions feature to filter unstructured instances.

NOTE: Controllers that makes use of Metac can benefit a lot from selector based matches of unstruct instances. This allows the code to filter specific instances than getting into nested branching logic.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>