### PR TITLE
feat(github-action): add github action to build image on every push

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,14 @@
+name: Build image
+on: [push]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+
+    - name: Check out mayadata-io/cstorpoolauto repo
+      uses: actions/checkout@v2
+
+    - name: Build docker image
+      run: make image


### PR DESCRIPTION
This PR adds GitHub action to run unit tests and build a docker image on every push.

Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>