### PR TITLE
fix(capacity): fix capacity bug due to invalid datatype parsing

### DIFF
--- a/types/raidgroupconfig.go
+++ b/types/raidgroupconfig.go
@@ -68,11 +68,11 @@ func (rgc *RaidGroupConfig) GetDataDeviceCount() int64 {
 	// where n block devices present in raid group config
 	case PoolRAIDTypeStripe:
 		return rgc.GroupDeviceCount
-	// For stripe pool data device count in is x - 1.
+	// For raidz pool data device count in is x - 1.
 	// where x = 2^n + 1 block devices present in raid group config
 	case PoolRAIDTypeRAIDZ:
 		return rgc.GroupDeviceCount - 1
-	// For stripe pool data device count in is x - 2.
+	// For raidz2 pool data device count in is x - 2.
 	// where x = 2^n + 2 block devices present in raid group config
 	case PoolRAIDTypeRAIDZ2:
 		return rgc.GroupDeviceCount - 2

--- a/types/raidgroupconfig.go
+++ b/types/raidgroupconfig.go
@@ -42,10 +42,10 @@ func GetDefaultRaidGroupConfig() *RaidGroupConfig {
 	}
 }
 
-// PopulateDefaultGroupDeviceCount populate default device count for
-// a given raid group. If device count is not set then only it sets
-// device count for a raid group else it will skip.
-func (rgc *RaidGroupConfig) PopulateDefaultGroupDeviceCount() error {
+// PopulateDefaultGroupDeviceCountIfNotPresent populate default device count for
+// a given raid group if device count is not set then. If device count for a raid
+// group present then it will skip.
+func (rgc *RaidGroupConfig) PopulateDefaultGroupDeviceCountIfNotPresent() error {
 	if rgc.GroupDeviceCount != 0 {
 		return nil
 	}
@@ -56,6 +56,29 @@ func (rgc *RaidGroupConfig) PopulateDefaultGroupDeviceCount() error {
 	}
 	rgc.GroupDeviceCount = dc
 	return nil
+}
+
+// GetDataDeviceCount returns data device count for one raid group configuration
+// This is helpfull to calculate pool capacity.
+func (rgc *RaidGroupConfig) GetDataDeviceCount() int64 {
+	switch rgc.Type {
+	case PoolRAIDTypeMirror:
+		return rgc.GroupDeviceCount / 2
+	// For stripe pool data device count in is n.
+	// where n block devices present in raid group config
+	case PoolRAIDTypeStripe:
+		return rgc.GroupDeviceCount
+	// For stripe pool data device count in is x - 1.
+	// where x = 2^n + 1 block devices present in raid group config
+	case PoolRAIDTypeRAIDZ:
+		return rgc.GroupDeviceCount - 1
+	// For stripe pool data device count in is x - 2.
+	// where x = 2^n + 2 block devices present in raid group config
+	case PoolRAIDTypeRAIDZ2:
+		return rgc.GroupDeviceCount - 2
+	default:
+		return 0
+	}
 }
 
 // Validate validates RaidGroupConfig

--- a/util/blockdevice/util.go
+++ b/util/blockdevice/util.go
@@ -195,3 +195,14 @@ func HasFileSystemOrError(obj unstructured.Unstructured) (bool, error) {
 	}
 	return true, nil
 }
+
+// GetDeviceTypeOrError return device type HDD or SSD. If not present
+// it returns an error.
+func GetDeviceTypeOrError(obj unstructured.Unstructured) (string, error) {
+	if obj.GetKind() != string(types.KindBlockDevice) {
+		return "",
+			errors.Errorf("Can not check file system: Expected kind %q got %q",
+				types.KindBlockDevice, obj.GetKind())
+	}
+	return unstruct.GetStringOrError(&obj, "spec", "details", "deviceType")
+}

--- a/util/blockdevice/util.go
+++ b/util/blockdevice/util.go
@@ -81,7 +81,7 @@ status:
 */
 
 // GetCapacityOrError returns capacity of a block device in resource.Quantity format
-// If value if not found or for an invalid capacity then it returns an error
+// If value not found or for an invalid capacity then it returns an error.
 func GetCapacityOrError(obj unstructured.Unstructured) (resource.Quantity, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return resource.Quantity{},
@@ -91,9 +91,9 @@ func GetCapacityOrError(obj unstructured.Unstructured) (resource.Quantity, error
 	return unstruct.GetInt64AsQuantityOrError(&obj, "spec", "capacity", "storage")
 }
 
-// GetLogicalSectorSizeOrError returns LogicalSectorSize of a block device in
-// resource.Quantity format If value if not found or for an invalid capacity
-// then it returns an error
+// GetLogicalSectorSizeOrError returns Logical Sector Size of a block device in
+// resource.Quantity format. If value not found or for an invalid Logical Sector
+// Size it returns an error.
 func GetLogicalSectorSizeOrError(obj unstructured.Unstructured) (resource.Quantity, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return resource.Quantity{},
@@ -103,9 +103,9 @@ func GetLogicalSectorSizeOrError(obj unstructured.Unstructured) (resource.Quanti
 	return unstruct.GetInt64AsQuantityOrError(&obj, "spec", "capacity", "logicalSectorSize")
 }
 
-// GetPhysicalSectorSizeOrError returns PhysicalSectorSize of a block device
-// in resource.Quantity format If value if not found or for an invalid capacity
-// then it returns an error
+// GetPhysicalSectorSizeOrError returns Physical Sector Size of a block device
+// in resource.Quantity format. If value not found or for an invalid Physical
+// Sector Size it returns an error.
 func GetPhysicalSectorSizeOrError(obj unstructured.Unstructured) (resource.Quantity, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return resource.Quantity{},

--- a/util/blockdevice/util.go
+++ b/util/blockdevice/util.go
@@ -88,7 +88,7 @@ func GetCapacityOrError(obj unstructured.Unstructured) (resource.Quantity, error
 			errors.Errorf("Can not get capacity: Expected kind %q got %q",
 				types.KindBlockDevice, obj.GetKind())
 	}
-	return unstruct.GetQuantityOrError(&obj, "spec", "capacity", "storage")
+	return unstruct.GetInt64AsQuantityOrError(&obj, "spec", "capacity", "storage")
 }
 
 // GetHostNameOrError returns kubernetes.io/hostname label value of a block device. If value
@@ -154,9 +154,9 @@ func IsUnclaimedOrError(obj unstructured.Unstructured) (bool, error) {
 	return false, nil
 }
 
-// HasSystemPresentOrError checks if any file system is present in the block device or not.
+// HasFileSystemOrError checks if any file system is present in the block device or not.
 // If file system is not present then it returns true.
-func HasSystemPresentOrError(obj unstructured.Unstructured) (bool, error) {
+func HasFileSystemOrError(obj unstructured.Unstructured) (bool, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return false,
 			errors.Errorf("Can not check file system: Expected kind %q got %q",

--- a/util/blockdevice/util.go
+++ b/util/blockdevice/util.go
@@ -91,6 +91,30 @@ func GetCapacityOrError(obj unstructured.Unstructured) (resource.Quantity, error
 	return unstruct.GetInt64AsQuantityOrError(&obj, "spec", "capacity", "storage")
 }
 
+// GetLogicalSectorSizeOrError returns LogicalSectorSize of a block device in
+// resource.Quantity format If value if not found or for an invalid capacity
+// then it returns an error
+func GetLogicalSectorSizeOrError(obj unstructured.Unstructured) (resource.Quantity, error) {
+	if obj.GetKind() != string(types.KindBlockDevice) {
+		return resource.Quantity{},
+			errors.Errorf("Can not get capacity: Expected kind %q got %q",
+				types.KindBlockDevice, obj.GetKind())
+	}
+	return unstruct.GetInt64AsQuantityOrError(&obj, "spec", "capacity", "logicalSectorSize")
+}
+
+// GetPhysicalSectorSizeOrError returns PhysicalSectorSize of a block device
+// in resource.Quantity format If value if not found or for an invalid capacity
+// then it returns an error
+func GetPhysicalSectorSizeOrError(obj unstructured.Unstructured) (resource.Quantity, error) {
+	if obj.GetKind() != string(types.KindBlockDevice) {
+		return resource.Quantity{},
+			errors.Errorf("Can not get capacity: Expected kind %q got %q",
+				types.KindBlockDevice, obj.GetKind())
+	}
+	return unstruct.GetInt64AsQuantityOrError(&obj, "spec", "capacity", "physicalSectorSize")
+}
+
 // GetHostNameOrError returns kubernetes.io/hostname label value of a block device. If value
 // is not found or value is empty it returns an error. Host name is the value of
 // kubernetes.io/hostname label of a node. NOTE - It may not be same with node name.

--- a/util/blockdevice/util_test.go
+++ b/util/blockdevice/util_test.go
@@ -699,3 +699,86 @@ func TestHasFileSystemOrError(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDeviceTypeOrError(t *testing.T) {
+	var tests = map[string]struct {
+		src    unstructured.Unstructured
+		result string
+		isErr  bool
+	}{
+		"nil object": {
+			src: unstructured.Unstructured{
+				Object: nil,
+			},
+			isErr: true,
+		},
+		"empty object": {
+			src:   unstructured.Unstructured{},
+			isErr: true,
+		},
+		"kind mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "test",
+				},
+			},
+			isErr: true,
+		},
+		"type mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"details": map[string]interface{}{
+							"deviceType": 1,
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"empty value error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"details": map[string]interface{}{
+							"deviceType": "",
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"device type present": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"details": map[string]interface{}{
+							"deviceType": "HDD",
+						},
+					},
+				},
+			},
+			result: "HDD",
+			isErr:  false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			result, err := GetDeviceTypeOrError(mock.src)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !mock.isErr && result != mock.result {
+				t.Fatalf("Expected file system check status %v got %v", mock.result, result)
+			}
+		})
+	}
+}

--- a/util/blockdevice/util_test.go
+++ b/util/blockdevice/util_test.go
@@ -244,9 +244,9 @@ func TestGetPhysicalSectorSizeOrError(t *testing.T) {
 
 func TestGetHostNameOrError(t *testing.T) {
 	var tests = map[string]struct {
-		src    unstructured.Unstructured
-		result string
-		isErr  bool
+		src              unstructured.Unstructured
+		expectedHostName string
+		isErr            bool
 	}{
 		"nil object": {
 			src: unstructured.Unstructured{
@@ -311,23 +311,23 @@ func TestGetHostNameOrError(t *testing.T) {
 					},
 				},
 			},
-			isErr:  false,
-			result: "my-host-1",
+			isErr:            false,
+			expectedHostName: "my-host-1",
 		},
 	}
 	for name, mock := range tests {
 		name := name
 		mock := mock
 		t.Run(name, func(t *testing.T) {
-			result, err := GetHostNameOrError(mock.src)
+			hostName, err := GetHostNameOrError(mock.src)
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}
 			if !mock.isErr && err != nil {
 				t.Fatalf("Expected no error got [%+v]", err)
 			}
-			if !mock.isErr && result != mock.result {
-				t.Fatalf("Expected host name %q got %q", mock.result, result)
+			if !mock.isErr && hostName != mock.expectedHostName {
+				t.Fatalf("Expected host name %q got %q", mock.expectedHostName, hostName)
 			}
 		})
 	}
@@ -335,9 +335,9 @@ func TestGetHostNameOrError(t *testing.T) {
 
 func TestGetNodeNameOrError(t *testing.T) {
 	var tests = map[string]struct {
-		src    unstructured.Unstructured
-		result string
-		isErr  bool
+		src              unstructured.Unstructured
+		expectedNodeName string
+		isErr            bool
 	}{
 		"nil object": {
 			src: unstructured.Unstructured{
@@ -402,23 +402,23 @@ func TestGetNodeNameOrError(t *testing.T) {
 					},
 				},
 			},
-			isErr:  false,
-			result: "my-host-1",
+			isErr:            false,
+			expectedNodeName: "my-host-1",
 		},
 	}
 	for name, mock := range tests {
 		name := name
 		mock := mock
 		t.Run(name, func(t *testing.T) {
-			result, err := GetNodeNameOrError(mock.src)
+			nodeName, err := GetNodeNameOrError(mock.src)
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}
 			if !mock.isErr && err != nil {
 				t.Fatalf("Expected no error got [%+v]", err)
 			}
-			if !mock.isErr && result != mock.result {
-				t.Fatalf("Expected node name %q got %q", mock.result, result)
+			if !mock.isErr && nodeName != mock.expectedNodeName {
+				t.Fatalf("Expected node name %q got %q", mock.expectedNodeName, nodeName)
 			}
 		})
 	}
@@ -426,9 +426,9 @@ func TestGetNodeNameOrError(t *testing.T) {
 
 func TestIsActiveOrError(t *testing.T) {
 	var tests = map[string]struct {
-		src    unstructured.Unstructured
-		result bool
-		isErr  bool
+		src      unstructured.Unstructured
+		isActive bool
+		isErr    bool
 	}{
 		"nil object": {
 			src: unstructured.Unstructured{
@@ -487,8 +487,8 @@ func TestIsActiveOrError(t *testing.T) {
 					},
 				},
 			},
-			isErr:  false,
-			result: false,
+			isErr:    false,
+			isActive: false,
 		},
 		"valid status and active": {
 			src: unstructured.Unstructured{
@@ -499,8 +499,8 @@ func TestIsActiveOrError(t *testing.T) {
 					},
 				},
 			},
-			isErr:  false,
-			result: true,
+			isErr:    false,
+			isActive: true,
 		},
 	}
 	for name, mock := range tests {
@@ -514,8 +514,8 @@ func TestIsActiveOrError(t *testing.T) {
 			if !mock.isErr && err != nil {
 				t.Fatalf("Expected no error got [%+v]", err)
 			}
-			if !mock.isErr && result != mock.result {
-				t.Fatalf("Expected status %t got %t", mock.result, result)
+			if !mock.isErr && result != mock.isActive {
+				t.Fatalf("Expected status %t got %t", mock.isActive, result)
 			}
 		})
 	}
@@ -523,9 +523,9 @@ func TestIsActiveOrError(t *testing.T) {
 
 func TestIsUnclaimedOrError(t *testing.T) {
 	var tests = map[string]struct {
-		src    unstructured.Unstructured
-		result bool
-		isErr  bool
+		src         unstructured.Unstructured
+		isUnclaimed bool
+		isErr       bool
 	}{
 		"nil object": {
 			src: unstructured.Unstructured{
@@ -584,8 +584,8 @@ func TestIsUnclaimedOrError(t *testing.T) {
 					},
 				},
 			},
-			isErr:  false,
-			result: false,
+			isErr:       false,
+			isUnclaimed: false,
 		},
 		"valid claim status and unclaimed": {
 			src: unstructured.Unstructured{
@@ -596,8 +596,8 @@ func TestIsUnclaimedOrError(t *testing.T) {
 					},
 				},
 			},
-			isErr:  false,
-			result: true,
+			isErr:       false,
+			isUnclaimed: true,
 		},
 	}
 	for name, mock := range tests {
@@ -611,8 +611,8 @@ func TestIsUnclaimedOrError(t *testing.T) {
 			if !mock.isErr && err != nil {
 				t.Fatalf("Expected no error got [%+v]", err)
 			}
-			if !mock.isErr && result != mock.result {
-				t.Fatalf("Expected claim status %t got %t", mock.result, result)
+			if !mock.isErr && result != mock.isUnclaimed {
+				t.Fatalf("Expected claim status %t got %t", mock.isUnclaimed, result)
 			}
 		})
 	}
@@ -620,9 +620,9 @@ func TestIsUnclaimedOrError(t *testing.T) {
 
 func TestHasFileSystemOrError(t *testing.T) {
 	var tests = map[string]struct {
-		src    unstructured.Unstructured
-		result bool
-		isErr  bool
+		src           unstructured.Unstructured
+		hasFileSystem bool
+		isErr         bool
 	}{
 		"nil object": {
 			src: unstructured.Unstructured{
@@ -666,8 +666,8 @@ func TestHasFileSystemOrError(t *testing.T) {
 					},
 				},
 			},
-			result: true,
-			isErr:  false,
+			hasFileSystem: true,
+			isErr:         false,
 		},
 		"file not system present": {
 			src: unstructured.Unstructured{
@@ -678,8 +678,8 @@ func TestHasFileSystemOrError(t *testing.T) {
 					},
 				},
 			},
-			result: false,
-			isErr:  false,
+			hasFileSystem: false,
+			isErr:         false,
 		},
 	}
 	for name, mock := range tests {
@@ -693,8 +693,8 @@ func TestHasFileSystemOrError(t *testing.T) {
 			if !mock.isErr && err != nil {
 				t.Fatalf("Expected no error got [%+v]", err)
 			}
-			if !mock.isErr && result != mock.result {
-				t.Fatalf("Expected file system check status %t got %t", mock.result, result)
+			if !mock.isErr && result != mock.hasFileSystem {
+				t.Fatalf("Expected file system check status %t got %t", mock.hasFileSystem, result)
 			}
 		})
 	}
@@ -702,9 +702,9 @@ func TestHasFileSystemOrError(t *testing.T) {
 
 func TestGetDeviceTypeOrError(t *testing.T) {
 	var tests = map[string]struct {
-		src    unstructured.Unstructured
-		result string
-		isErr  bool
+		src                unstructured.Unstructured
+		expectedDeviceType string
+		isErr              bool
 	}{
 		"nil object": {
 			src: unstructured.Unstructured{
@@ -761,8 +761,8 @@ func TestGetDeviceTypeOrError(t *testing.T) {
 					},
 				},
 			},
-			result: "HDD",
-			isErr:  false,
+			expectedDeviceType: "HDD",
+			isErr:              false,
 		},
 	}
 	for name, mock := range tests {
@@ -776,8 +776,8 @@ func TestGetDeviceTypeOrError(t *testing.T) {
 			if !mock.isErr && err != nil {
 				t.Fatalf("Expected no error got [%+v]", err)
 			}
-			if !mock.isErr && result != mock.result {
-				t.Fatalf("Expected file system check status %v got %v", mock.result, result)
+			if !mock.isErr && result != mock.expectedDeviceType {
+				t.Fatalf("Expected file system check status %v got %v", mock.expectedDeviceType, result)
 			}
 		})
 	}

--- a/util/blockdevice/util_test.go
+++ b/util/blockdevice/util_test.go
@@ -54,65 +54,26 @@ func TestGetCapacityOrError(t *testing.T) {
 			},
 			isErr: true,
 		},
-		"empty value error": {
-			src: unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"kind": string(types.KindBlockDevice),
-					"spec": map[string]interface{}{
-						"capacity": map[string]interface{}{
-							"storage": "",
-						},
-					},
-				},
-			},
-			isErr: true,
-		},
 		"type mismatch error": {
 			src: unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind": string(types.KindBlockDevice),
 					"spec": map[string]interface{}{
 						"capacity": map[string]interface{}{
-							"storage": 0,
+							"storage": "test",
 						},
 					},
 				},
 			},
 			isErr: true,
 		},
-		"invalid capacity error": {
+		"valid capacity": {
 			src: unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind": string(types.KindBlockDevice),
 					"spec": map[string]interface{}{
 						"capacity": map[string]interface{}{
-							"storage": "10000A",
-						},
-					},
-				},
-			},
-			isErr: true,
-		},
-		"valid object-1": {
-			src: unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"kind": string(types.KindBlockDevice),
-					"spec": map[string]interface{}{
-						"capacity": map[string]interface{}{
-							"storage": "1000G",
-						},
-					},
-				},
-			},
-			isErr: false,
-		},
-		"valid object-2": {
-			src: unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"kind": string(types.KindBlockDevice),
-					"spec": map[string]interface{}{
-						"capacity": map[string]interface{}{
-							"storage": "1000Gi",
+							"storage": int64(1000),
 						},
 					},
 				},
@@ -130,6 +91,610 @@ func TestGetCapacityOrError(t *testing.T) {
 			}
 			if !mock.isErr && err != nil {
 				t.Fatalf("Expected no error got [%+v]", err)
+			}
+		})
+	}
+}
+
+func TestGetLogicalSectorSizeOrError(t *testing.T) {
+	var tests = map[string]struct {
+		src   unstructured.Unstructured
+		isErr bool
+	}{
+		"nil object": {
+			src: unstructured.Unstructured{
+				Object: nil,
+			},
+			isErr: true,
+		},
+		"empty object": {
+			src:   unstructured.Unstructured{},
+			isErr: true,
+		},
+		"kind mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "test",
+				},
+			},
+			isErr: true,
+		},
+		"not found error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+				},
+			},
+			isErr: true,
+		},
+		"type mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"capacity": map[string]interface{}{
+							"logicalSectorSize": "test",
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"valid logical sector size": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"capacity": map[string]interface{}{
+							"logicalSectorSize": int64(512),
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			_, err := GetLogicalSectorSizeOrError(mock.src)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+		})
+	}
+}
+
+func TestGetPhysicalSectorSizeOrError(t *testing.T) {
+	var tests = map[string]struct {
+		src   unstructured.Unstructured
+		isErr bool
+	}{
+		"nil object": {
+			src: unstructured.Unstructured{
+				Object: nil,
+			},
+			isErr: true,
+		},
+		"empty object": {
+			src:   unstructured.Unstructured{},
+			isErr: true,
+		},
+		"kind mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "test",
+				},
+			},
+			isErr: true,
+		},
+		"not found error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+				},
+			},
+			isErr: true,
+		},
+		"type mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"capacity": map[string]interface{}{
+							"physicalSectorSize": "test",
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"valid physical sector size": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"capacity": map[string]interface{}{
+							"physicalSectorSize": int64(1000),
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			_, err := GetPhysicalSectorSizeOrError(mock.src)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+		})
+	}
+}
+
+func TestGetHostNameOrError(t *testing.T) {
+	var tests = map[string]struct {
+		src    unstructured.Unstructured
+		result string
+		isErr  bool
+	}{
+		"nil object": {
+			src: unstructured.Unstructured{
+				Object: nil,
+			},
+			isErr: true,
+		},
+		"empty object": {
+			src:   unstructured.Unstructured{},
+			isErr: true,
+		},
+		"kind mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "test",
+				},
+			},
+			isErr: true,
+		},
+		"not found error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+				},
+			},
+			isErr: true,
+		},
+		"empty value error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"kubernetes.io/hostname": "",
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"type mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"kubernetes.io/hostname": 1,
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"valid hostname label": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"kubernetes.io/hostname": "my-host-1",
+						},
+					},
+				},
+			},
+			isErr:  false,
+			result: "my-host-1",
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			result, err := GetHostNameOrError(mock.src)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !mock.isErr && result != mock.result {
+				t.Fatalf("Expected host name %q got %q", mock.result, result)
+			}
+		})
+	}
+}
+
+func TestGetNodeNameOrError(t *testing.T) {
+	var tests = map[string]struct {
+		src    unstructured.Unstructured
+		result string
+		isErr  bool
+	}{
+		"nil object": {
+			src: unstructured.Unstructured{
+				Object: nil,
+			},
+			isErr: true,
+		},
+		"empty object": {
+			src:   unstructured.Unstructured{},
+			isErr: true,
+		},
+		"kind mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "test",
+				},
+			},
+			isErr: true,
+		},
+		"not found error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+				},
+			},
+			isErr: true,
+		},
+		"empty value error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"nodeAttributes": map[string]interface{}{
+							"nodeName": "",
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"type mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"nodeAttributes": map[string]interface{}{
+							"nodeName": 1,
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"valid node name": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"nodeAttributes": map[string]interface{}{
+							"nodeName": "my-host-1",
+						},
+					},
+				},
+			},
+			isErr:  false,
+			result: "my-host-1",
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			result, err := GetNodeNameOrError(mock.src)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !mock.isErr && result != mock.result {
+				t.Fatalf("Expected node name %q got %q", mock.result, result)
+			}
+		})
+	}
+}
+
+func TestIsActiveOrError(t *testing.T) {
+	var tests = map[string]struct {
+		src    unstructured.Unstructured
+		result bool
+		isErr  bool
+	}{
+		"nil object": {
+			src: unstructured.Unstructured{
+				Object: nil,
+			},
+			isErr: true,
+		},
+		"empty object": {
+			src:   unstructured.Unstructured{},
+			isErr: true,
+		},
+		"kind mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "test",
+				},
+			},
+			isErr: true,
+		},
+		"not found error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+				},
+			},
+			isErr: true,
+		},
+		"empty value error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"status": map[string]interface{}{
+						"state": "",
+					},
+				},
+			},
+			isErr: true,
+		},
+		"type mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"status": map[string]interface{}{
+						"state": 1,
+					},
+				},
+			},
+			isErr: true,
+		},
+		"valid status and inactive": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"status": map[string]interface{}{
+						"state": string(types.BlockDeviceInactive),
+					},
+				},
+			},
+			isErr:  false,
+			result: false,
+		},
+		"valid status and active": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"status": map[string]interface{}{
+						"state": string(types.BlockDeviceActive),
+					},
+				},
+			},
+			isErr:  false,
+			result: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			result, err := IsActiveOrError(mock.src)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !mock.isErr && result != mock.result {
+				t.Fatalf("Expected status %t got %t", mock.result, result)
+			}
+		})
+	}
+}
+
+func TestIsUnclaimedOrError(t *testing.T) {
+	var tests = map[string]struct {
+		src    unstructured.Unstructured
+		result bool
+		isErr  bool
+	}{
+		"nil object": {
+			src: unstructured.Unstructured{
+				Object: nil,
+			},
+			isErr: true,
+		},
+		"empty object": {
+			src:   unstructured.Unstructured{},
+			isErr: true,
+		},
+		"kind mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "test",
+				},
+			},
+			isErr: true,
+		},
+		"not found error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+				},
+			},
+			isErr: true,
+		},
+		"empty value error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"status": map[string]interface{}{
+						"claimState": "",
+					},
+				},
+			},
+			isErr: true,
+		},
+		"type mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"status": map[string]interface{}{
+						"claimState": 1,
+					},
+				},
+			},
+			isErr: true,
+		},
+		"valid claim status and claimed": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"status": map[string]interface{}{
+						"claimState": string(types.BlockDeviceClaimed),
+					},
+				},
+			},
+			isErr:  false,
+			result: false,
+		},
+		"valid claim status and unclaimed": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"status": map[string]interface{}{
+						"claimState": string(types.BlockDeviceUnclaimed),
+					},
+				},
+			},
+			isErr:  false,
+			result: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			result, err := IsUnclaimedOrError(mock.src)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !mock.isErr && result != mock.result {
+				t.Fatalf("Expected claim status %t got %t", mock.result, result)
+			}
+		})
+	}
+}
+
+func TestHasFileSystemOrError(t *testing.T) {
+	var tests = map[string]struct {
+		src    unstructured.Unstructured
+		result bool
+		isErr  bool
+	}{
+		"nil object": {
+			src: unstructured.Unstructured{
+				Object: nil,
+			},
+			isErr: true,
+		},
+		"empty object": {
+			src:   unstructured.Unstructured{},
+			isErr: true,
+		},
+		"kind mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "test",
+				},
+			},
+			isErr: true,
+		},
+		"type mismatch error": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"filesystem": map[string]interface{}{
+							"fsType": 1,
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"file system present": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"filesystem": map[string]interface{}{
+							"fsType": "ext4",
+						},
+					},
+				},
+			},
+			result: true,
+			isErr:  false,
+		},
+		"file not system present": {
+			src: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+					"spec": map[string]interface{}{
+						"filesystem": map[string]interface{}{},
+					},
+				},
+			},
+			result: false,
+			isErr:  false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			result, err := HasFileSystemOrError(mock.src)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !mock.isErr && result != mock.result {
+				t.Fatalf("Expected file system check status %t got %t", mock.result, result)
 			}
 		})
 	}


### PR DESCRIPTION
This commit has following changes:
- 1/ fix utility function for block-device.
  - bug: blockdevice spec.capacity.storage is a int64 type but logic reads it as a string
  - fix: use int64 & subsequently convert it to resource.Quantity format.
- 2/ additional util functions for block-device and raid group config.
- 3/ new unit tests for all utility functions.

Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>