### PR TITLE
rename(bdutil): rename utility functions in bdutil package

### DIFF
--- a/util/blockdevice/topology.go
+++ b/util/blockdevice/topology.go
@@ -101,7 +101,7 @@ func GetTopologyMapGroupByDeviceTypeAndBlockSize(
 
 		// If capacity is missing or we got any error during fetching capacity then
 		// we can not use that block device to create topology map.
-		capacity, err := GetCapacityOrError(bd)
+		capacity, err := GetCapacity(bd)
 		if err != nil {
 			// TODO log the error
 			continue
@@ -110,8 +110,12 @@ func GetTopologyMapGroupByDeviceTypeAndBlockSize(
 		// Device type represents block device type ie - (HDD, SSD)
 		// If Device type is empty or we got any error during fetching this then
 		// add that block device in unknown group.
-		deviceType, err := GetDeviceTypeOrError(bd)
+		deviceType, err := GetDeviceType(bd)
 		if err != nil {
+			continue
+		}
+		// If deviceType is empty then add it to unknown device type group
+		if deviceType != "" {
 			deviceType = DeviceKindUnKnown
 		}
 
@@ -136,7 +140,7 @@ func GetTopologyMapGroupByDeviceTypeAndBlockSize(
 
 		// get the physical block size if error is nil and it is not zero
 		// then add a top level key for it.
-		physicalBlockSize, err := GetPhysicalSectorSizeOrError(bd)
+		physicalBlockSize, err := GetPhysicalSectorSize(bd)
 		if err == nil && !physicalBlockSize.IsZero() {
 			deviceTypeList = append(deviceTypeList, fmt.Sprintf("%s-%s", deviceType, physicalBlockSize.String()))
 		}

--- a/util/blockdevice/util.go
+++ b/util/blockdevice/util.go
@@ -80,76 +80,114 @@ status:
 ```
 */
 
-// GetCapacityOrError returns capacity of a block device in resource.Quantity format
-// If value not found or for an invalid capacity then it returns an error.
-func GetCapacityOrError(obj unstructured.Unstructured) (resource.Quantity, error) {
+// GetCapacity returns capacity of a block device in resource.Quantity format
+// If json path not found or for an invalid capacity it returns an error.
+func GetCapacity(obj unstructured.Unstructured) (resource.Quantity, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return resource.Quantity{},
 			errors.Errorf("Can not get capacity: Expected kind %q got %q",
 				types.KindBlockDevice, obj.GetKind())
 	}
-	return unstruct.GetInt64AsQuantityOrError(&obj, "spec", "capacity", "storage")
+	return unstruct.GetInt64AsQuantity(&obj, "spec", "capacity", "storage")
 }
 
-// GetLogicalSectorSizeOrError returns Logical Sector Size of a block device in
-// resource.Quantity format. If value not found or for an invalid Logical Sector
-// Size it returns an error.
-func GetLogicalSectorSizeOrError(obj unstructured.Unstructured) (resource.Quantity, error) {
+// GetLogicalSectorSize returns Logical Sector Size of a block device in
+// resource.Quantity format. If json path not found or for an invalid capacity
+// it returns an error.
+func GetLogicalSectorSize(obj unstructured.Unstructured) (resource.Quantity, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return resource.Quantity{},
 			errors.Errorf("Can not get capacity: Expected kind %q got %q",
 				types.KindBlockDevice, obj.GetKind())
 	}
-	return unstruct.GetInt64AsQuantityOrError(&obj, "spec", "capacity", "logicalSectorSize")
+	return unstruct.GetInt64AsQuantity(&obj, "spec", "capacity", "logicalSectorSize")
 }
 
-// GetPhysicalSectorSizeOrError returns Physical Sector Size of a block device
-// in resource.Quantity format. If value not found or for an invalid Physical
-// Sector Size it returns an error.
-func GetPhysicalSectorSizeOrError(obj unstructured.Unstructured) (resource.Quantity, error) {
+// GetPhysicalSectorSize returns Physical Sector Size of a block device
+// in resource.Quantity format. If json path not found or for an invalid capacity
+// it returns an error.
+func GetPhysicalSectorSize(obj unstructured.Unstructured) (resource.Quantity, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return resource.Quantity{},
 			errors.Errorf("Can not get capacity: Expected kind %q got %q",
 				types.KindBlockDevice, obj.GetKind())
 	}
-	return unstruct.GetInt64AsQuantityOrError(&obj, "spec", "capacity", "physicalSectorSize")
+	return unstruct.GetInt64AsQuantity(&obj, "spec", "capacity", "physicalSectorSize")
+}
+
+// GetHostName returns kubernetes.io/hostname label value of a block device. If value
+// is not found or path key not found it returns an error. Host name is the value of
+// kubernetes.io/hostname label of a node. NOTE - It may not be same with node name.
+func GetHostName(obj unstructured.Unstructured) (string, error) {
+	if obj.GetKind() != string(types.KindBlockDevice) {
+		return "", errors.Errorf("Can not get host name: Expected kind %q got %q",
+			types.KindBlockDevice, obj.GetKind())
+	}
+	return unstruct.GetString(&obj, "metadata", "labels", "kubernetes.io/hostname")
 }
 
 // GetHostNameOrError returns kubernetes.io/hostname label value of a block device. If value
-// is not found or value is empty it returns an error. Host name is the value of
-// kubernetes.io/hostname label of a node. NOTE - It may not be same with node name.
+// is not found or path key not found or if value is empty it returns an error. Host name is
+// the value of kubernetes.io/hostname label of a node. NOTE - It may not be same with node name.
 func GetHostNameOrError(obj unstructured.Unstructured) (string, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return "", errors.Errorf("Can not get host name: Expected kind %q got %q",
 			types.KindBlockDevice, obj.GetKind())
 	}
-	return unstruct.GetStringOrError(&obj, "metadata", "labels", "kubernetes.io/hostname")
+	value, err := GetHostName(obj)
+	if err != nil {
+		return "", err
+	}
+	if value == "" {
+		return "", errors.New("Can not get host name: Found empty host name")
+	}
+	return value, nil
 }
 
-// GetNodeNameOrError returns the node name in which given block device is attached. This is
+// GetNodeName returns the node name in which given block device is attached. This is
 // not kubernetes.io/hostname label value of a node. NOTE - name of node and label value
-// may be different.
+// may be different. If value is not found or path key not found it returns an error.
+func GetNodeName(obj unstructured.Unstructured) (string, error) {
+	if obj.GetKind() != string(types.KindBlockDevice) {
+		return "",
+			errors.Errorf("Can not get node name: Expected kind %q got %q",
+				types.KindBlockDevice, obj.GetKind())
+	}
+	return unstruct.GetString(&obj, "spec", "nodeAttributes", "nodeName")
+}
+
+// GetNodeNameOrError returns the node name in which given block device
+// is attached. This is not kubernetes.io/hostname label value of a node.
+// NOTE - name of node and label value may be different. If value is not
+// found or path key not found or for empty value it returns an error.
 func GetNodeNameOrError(obj unstructured.Unstructured) (string, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return "",
 			errors.Errorf("Can not get node name: Expected kind %q got %q",
 				types.KindBlockDevice, obj.GetKind())
 	}
-	return unstruct.GetStringOrError(&obj, "spec", "nodeAttributes", "nodeName")
+	value, err := GetNodeName(obj)
+	if err != nil {
+		return "", err
+	}
+	if value == "" {
+		return "", errors.New("Can not get node name: Found empty node name")
+	}
+	return value, nil
 }
 
-// IsActiveOrError checks the status of one blockdevice if it is Active then it returns true.
+// IsActive checks the status of one blockdevice if it is Active then it returns true.
 // Possible states are - Active, Inactive, Unknown
 // Active - attached with one node.
 // Inactive - detached from node.
 // Unknown -  not able to get the status.
-func IsActiveOrError(obj unstructured.Unstructured) (bool, error) {
+func IsActive(obj unstructured.Unstructured) (bool, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return false,
 			errors.Errorf("Can not get status: Expected kind %q got %q",
 				types.KindBlockDevice, obj.GetKind())
 	}
-	value, err := unstruct.GetStringOrError(&obj, "status", "state")
+	value, err := unstruct.GetString(&obj, "status", "state")
 	if err != nil {
 		return false, err
 	}
@@ -159,16 +197,16 @@ func IsActiveOrError(obj unstructured.Unstructured) (bool, error) {
 	return false, nil
 }
 
-// IsUnclaimedOrError checks the claim status of one blockdevice if it is Unclaimed then
+// IsUnclaimed checks the claim status of one blockdevice if it is Unclaimed then
 // it returns true. Possible states are - Unclaimed, Claimed, Released.
 // - Unclaimed means no one is using this block device.
-func IsUnclaimedOrError(obj unstructured.Unstructured) (bool, error) {
+func IsUnclaimed(obj unstructured.Unstructured) (bool, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return false,
 			errors.Errorf("Can not get claim status: Expected kind %q got %q",
 				types.KindBlockDevice, obj.GetKind())
 	}
-	value, err := unstruct.GetStringOrError(&obj, "status", "claimState")
+	value, err := unstruct.GetString(&obj, "status", "claimState")
 	if err != nil {
 		return false, err
 	}
@@ -178,9 +216,9 @@ func IsUnclaimedOrError(obj unstructured.Unstructured) (bool, error) {
 	return false, nil
 }
 
-// HasFileSystemOrError checks if any file system is present in the block device or not.
+// HasFileSystem checks if any file system is present in the block device or not.
 // If file system is not present then it returns true.
-func HasFileSystemOrError(obj unstructured.Unstructured) (bool, error) {
+func HasFileSystem(obj unstructured.Unstructured) (bool, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return false,
 			errors.Errorf("Can not check file system: Expected kind %q got %q",
@@ -196,15 +234,15 @@ func HasFileSystemOrError(obj unstructured.Unstructured) (bool, error) {
 	return true, nil
 }
 
-// GetDeviceTypeOrError return device type HDD or SSD. If not present
+// GetDeviceType return device type HDD or SSD. If not present
 // it returns an error.
-func GetDeviceTypeOrError(obj unstructured.Unstructured) (string, error) {
+func GetDeviceType(obj unstructured.Unstructured) (string, error) {
 	if obj.GetKind() != string(types.KindBlockDevice) {
 		return "",
 			errors.Errorf("Can not check file system: Expected kind %q got %q",
 				types.KindBlockDevice, obj.GetKind())
 	}
-	return unstruct.GetStringOrError(&obj, "spec", "details", "deviceType")
+	return unstruct.GetString(&obj, "spec", "details", "deviceType")
 }
 
 // IsEligibleForCStorPool checks eligibility criteria to create a cStor pool.
@@ -220,7 +258,7 @@ func IsEligibleForCStorPool(obj unstructured.Unstructured) (bool, error) {
 	// If block device is not in active state or we got any error while
 	// fetching block device status then we can not use that block device
 	// to create a cStor pool.
-	isActive, err := IsActiveOrError(obj)
+	isActive, err := IsActive(obj)
 	if err != nil {
 		return false, errors.Wrap(err, "Can not check eligibility for cStor pool.")
 	}
@@ -231,7 +269,7 @@ func IsEligibleForCStorPool(obj unstructured.Unstructured) (bool, error) {
 	// If claim status block device is 'Claimed' or 'Released' or if we got
 	// any error while fetching claim status of block device then we can not
 	// use that block device to create a cStor pool.
-	isUnclaimed, err := IsUnclaimedOrError(obj)
+	isUnclaimed, err := IsUnclaimed(obj)
 	if err != nil {
 		return false, errors.Wrap(err, "Can not check eligibility for cStor pool.")
 	}
@@ -242,7 +280,7 @@ func IsEligibleForCStorPool(obj unstructured.Unstructured) (bool, error) {
 	// If file system present in the block device or we got any error while
 	// fetching file system details of the block device then we can not use
 	// that block device to create a cStor pool.
-	hasFileSystem, err := HasFileSystemOrError(obj)
+	hasFileSystem, err := HasFileSystem(obj)
 	if err != nil {
 		return false, errors.Wrap(err, "Can not check eligibility for cStor pool.")
 	}


### PR DESCRIPTION
Rename utility functions in bdutil package to avoid confusion

- function name ends with error will return error if there is an error or value is empty or not matching.
- function name not ends with error will return error if there is an error.

Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>