### PR TITLE
feat(recommendation): add device based recommendation for given configuration

### DIFF
--- a/pkg/recommendation/capacity.go
+++ b/pkg/recommendation/capacity.go
@@ -150,6 +150,7 @@ func (r *capacityRecommendationRequest) GetRecommendation() map[string]CapacityR
 			resultMap[kind] = cr
 		}
 	}
+
 	return resultMap
 }
 
@@ -183,8 +184,8 @@ func (cc capacityCount) getCapacityRecommendation(
 		MaxCapacity: resource.Quantity{},
 	}
 
-	// Ideally caller will check raid group config is valid not
-	// If invalid raid config passed then it will not return error.
+	// Ideally caller will check raid group config is valid or not
+	// If invalid raid config is passed then it will not return error.
 	// It only logs the error and return empty struct
 	if err := raidConfig.Validate(); err != nil {
 		// TODO log the error.
@@ -262,7 +263,7 @@ func (ncc nodeCapacityCount) getCapacityRecommendation(
 		MaxCapacity: resource.Quantity{},
 	}
 
-	// Ideally caller will check raid group config is valid not
+	// Ideally caller will check raid group config is valid or not
 	// If invalid raid config passed then it will not return error.
 	// It only logs the error and return empty struct
 	if err := raidConfig.Validate(); err != nil {

--- a/pkg/recommendation/device.go
+++ b/pkg/recommendation/device.go
@@ -11,54 +11,44 @@ import (
 	bdutil "mayadata.io/cstorpoolauto/util/blockdevice"
 )
 
-// nodeCapacityBlockDevice contains key with node name and value with capacityBlockDevice
-type nodeCapacityBlockDevice map[string]capacityBlockDevices
-
-// capacityBlockDevices contains a key with capacity of block device and
-// value with all the block devices of that capacity.
-type capacityBlockDevices map[int64][]bdutil.MetaInfo
-
 // cStorPoolClusterRecommendationRequest is used to request the device
 // recommendation for a given raid type.
 type cStorPoolClusterRecommendationRequest struct {
-	Spec types.CStorPoolClusterRecommendationRequestSpec
+	Request types.CStorPoolClusterRecommendationRequest
+	Data    Data
 }
 
 // Data is the input data requested for the specifix recommendation.
 type Data struct {
-	RaidConfig      *types.RaidGroupConfig
 	BlockDeviceList *unstructured.UnstructuredList
-	PoolCapacity    *resource.Quantity
 }
 
 // NewRequestForDevice returns a device request object after validation.
-func NewRequestForDevice(data *Data) (
+func NewRequestForDevice(request *types.CStorPoolClusterRecommendationRequest, data *Data) (
 	*cStorPoolClusterRecommendationRequest, error) {
 
-	if data.RaidConfig == nil {
+	if request.Spec.PoolCapacity.IsZero() {
 		return nil, errors.New(
-			"Unable to create device recommendation request: Got nil raid config")
-	}
-	if data.PoolCapacity == nil {
-		return nil, errors.New(
-			"Unable to create device recommendation request: Got nil pool capacity")
+			"Unable to create device recommendation request: Got zero pool capacity")
 	}
 	if data.BlockDeviceList == nil {
 		return nil, errors.New(
 			"Unable to create device recommendation request: Got nil block device list")
 	}
 
-	err := data.RaidConfig.Validate()
+	err := request.Spec.DataConfig.Validate()
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to create capacity recommendation request")
 	}
 
 	cspcrr := cStorPoolClusterRecommendationRequest{
-		Spec: types.CStorPoolClusterRecommendationRequestSpec{
-			PoolCapacity:    *data.PoolCapacity,
-			BlockDeviceList: *data.BlockDeviceList,
-			DataConfig:      *data.RaidConfig,
+		Request: types.CStorPoolClusterRecommendationRequest{
+			Spec: types.CStorPoolClusterRecommendationRequestSpec{
+				PoolCapacity: request.Spec.PoolCapacity,
+				DataConfig:   request.Spec.DataConfig,
+			},
 		},
+		Data: *data,
 	}
 
 	return &cspcrr, nil
@@ -69,17 +59,17 @@ func (r *cStorPoolClusterRecommendationRequest) GetRecommendation() map[string]t
 
 	cStorPoolClusterRecommendation := make(map[string]types.CStorPoolClusterRecommendation)
 
-	if len(r.Spec.BlockDeviceList.Items) == 0 {
+	if len(r.Data.BlockDeviceList.Items) == 0 {
 		return cStorPoolClusterRecommendation
 	}
 
-	if err := r.Spec.DataConfig.Validate(); err != nil {
+	if err := r.Request.Spec.DataConfig.Validate(); err != nil {
 		return cStorPoolClusterRecommendation
 	}
 
 	availableBlockDeviceList := unstructured.UnstructuredList{}
-	availableBlockDeviceList.Object = r.Spec.BlockDeviceList.Object
-	for _, bd := range r.Spec.BlockDeviceList.Items {
+	availableBlockDeviceList.Object = r.Data.BlockDeviceList.Object
+	for _, bd := range r.Data.BlockDeviceList.Items {
 		isEligible, err := bdutil.IsEligibleForCStorPool(bd)
 		if err == nil && isEligible {
 			availableBlockDeviceList.Items = append(availableBlockDeviceList.Items, bd)
@@ -96,7 +86,7 @@ func (r *cStorPoolClusterRecommendationRequest) GetRecommendation() map[string]t
 
 	for kind, nodeBlockDeviceListMap := range deviceTypeNodeBlockDeviceMap {
 
-		nodeCapacityBlockDeviceMap := nodeCapacityBlockDevice{}
+		nodeCapacityBlockDeviceMap := nodeCapacityBlockDevices{}
 
 		for nodeName, blockDeviceList := range nodeBlockDeviceListMap {
 
@@ -120,17 +110,19 @@ func (r *cStorPoolClusterRecommendationRequest) GetRecommendation() map[string]t
 			nodeCapacityBlockDeviceMap.update(nodeName, capacityBlockDevicesMap)
 		}
 
-		cStorPoolClusterRecommendation[kind] = nodeCapacityBlockDeviceMap.getDeviceRecommendtion(r.Spec.PoolCapacity, r.Spec.DataConfig)
-		cStorPoolClusterRecommendationValue := cStorPoolClusterRecommendation[kind]
-		cStorPoolClusterRecommendationValue.RequestSpec = r.Spec
+		cStorPoolClusterRecommendationValue := nodeCapacityBlockDeviceMap.getDeviceRecommendtion(r.Request.Spec.PoolCapacity, r.Request.Spec.DataConfig)
+		cStorPoolClusterRecommendationValue.RequestSpec = r.Request.Spec
 		cStorPoolClusterRecommendation[kind] = cStorPoolClusterRecommendationValue
 	}
 
 	return cStorPoolClusterRecommendation
 }
 
+// nodeCapacityBlockDevice contains key with node name and value with capacityBlockDevice
+type nodeCapacityBlockDevices map[string]capacityBlockDevices
+
 // getDeviceRecommendtion returns the recommended block devices on a node with the given configuration.
-func (ncb nodeCapacityBlockDevice) getDeviceRecommendtion(poolCapacity resource.Quantity, raidConfig types.RaidGroupConfig) types.CStorPoolClusterRecommendation {
+func (ncb nodeCapacityBlockDevices) getDeviceRecommendtion(poolCapacity resource.Quantity, raidConfig types.RaidGroupConfig) types.CStorPoolClusterRecommendation {
 
 	poolCapacityInt, ok := poolCapacity.AsInt64()
 	if !ok {
@@ -141,69 +133,10 @@ func (ncb nodeCapacityBlockDevice) getDeviceRecommendtion(poolCapacity resource.
 
 	for nodeName, capacityBlockDevices := range ncb {
 
-		poolInstance := types.PoolInstanceConfig{
-			Node: types.Reference{
-				Name: nodeName,
-			},
-			Capacity: poolCapacity,
-		}
+		poolInstance := capacityBlockDevices.getPoolInstance(poolCapacityInt, raidConfig)
+		poolInstance.Node.Name = nodeName
+		poolInstance.Capacity = poolCapacity
 
-		// To sort map storing (ascending order) keys in a seperate data structure.
-		// Note: map cannot be sorted.
-		capacityKeys := make([]int64, 0, len(capacityBlockDevices))
-		for capacity := range capacityBlockDevices {
-			capacityKeys = append(capacityKeys, capacity)
-		}
-		sort.SliceStable(capacityKeys, func(i, j int) bool {
-			return capacityKeys[i] < capacityKeys[j]
-		})
-
-		prevDataDevices := []types.Reference{}
-		for _, capacity := range capacityKeys {
-			dataDevices := []types.Reference{}
-
-			blockDevices := capacityBlockDevices[capacity]
-			count := int64(len(blockDevices))
-
-			if count < raidConfig.GroupDeviceCount {
-				continue
-			}
-
-			noOfRaidGroup := count / raidConfig.GroupDeviceCount
-
-			maxCapacity := noOfRaidGroup * raidConfig.GetDataDeviceCount() * capacity
-
-			// If required pool capacity is greater than the max capacity of
-			// the current block devices then skip this device.
-			if maxCapacity < poolCapacityInt {
-				continue
-			}
-
-			// Calculate the no of block devices to return to client.
-			noOfBlockDevices := (poolCapacityInt / capacity) * raidConfig.GroupDeviceCount
-			if poolCapacityInt < capacity {
-				noOfBlockDevices = raidConfig.GroupDeviceCount
-			}
-			for i := 0; i < int(noOfBlockDevices); i++ {
-				dataDevices = append(dataDevices, *blockDevices[i].Identity)
-			}
-
-			// Lets say someone requested for a 100GB pool with mirror type and the node
-			// contains both 50GB and 100GB of block devices.
-			// This will break the loop once suitable block device is found and return the last block devices.
-			// In this case 100GB.
-			if len(prevDataDevices) != 0 && (poolCapacityInt < capacity) {
-				break
-			}
-
-			// maintaining the prevDataDevices that means previous capacity suitable
-			// block devices for requested pool capacity.
-			prevDataDevices = dataDevices
-		}
-
-		poolInstance.BlockDevices = types.BlockDeviceTopology{
-			DataDevices: prevDataDevices,
-		}
 		poolInstances = append(poolInstances, poolInstance)
 
 	}
@@ -217,9 +150,76 @@ func (ncb nodeCapacityBlockDevice) getDeviceRecommendtion(poolCapacity resource.
 	return CStorPoolClusterRecommendation
 }
 
+// capacityBlockDevices contains a key with capacity of block device and
+// value with all the block devices of that capacity.
+type capacityBlockDevices map[int64][]bdutil.MetaInfo
+
+func (cbd capacityBlockDevices) getPoolInstance(poolCapacityInt int64, raidConfig types.RaidGroupConfig) types.PoolInstanceConfig {
+	// To sort map storing (ascending order) keys in a seperate data structure.
+	// Note: map cannot be sorted.
+	capacityKeys := make([]int64, 0, len(cbd))
+	for capacity := range cbd {
+		capacityKeys = append(capacityKeys, capacity)
+	}
+	sort.SliceStable(capacityKeys, func(i, j int) bool {
+		return capacityKeys[i] < capacityKeys[j]
+	})
+
+	prevDataDevices := []types.Reference{}
+	for _, capacity := range capacityKeys {
+		dataDevices := []types.Reference{}
+
+		blockDevices := cbd[capacity]
+		count := int64(len(blockDevices))
+
+		if count < raidConfig.GroupDeviceCount {
+			continue
+		}
+
+		noOfRaidGroup := count / raidConfig.GroupDeviceCount
+
+		maxCapacity := noOfRaidGroup * raidConfig.GetDataDeviceCount() * capacity
+
+		// If required pool capacity is greater than the max capacity of
+		// the current block devices then skip this device.
+		if maxCapacity < poolCapacityInt {
+			continue
+		}
+
+		// Calculate the no of block devices to return to client.
+		noOfBlockDevices := (poolCapacityInt / capacity) * raidConfig.GroupDeviceCount
+		if poolCapacityInt < capacity {
+			noOfBlockDevices = raidConfig.GroupDeviceCount
+		}
+		for i := 0; i < int(noOfBlockDevices); i++ {
+			dataDevices = append(dataDevices, *blockDevices[i].Identity)
+		}
+
+		// Lets say someone requested for a 100GB pool with mirror type and the node
+		// contains both 50GB and 100GB of block devices.
+		// This will break the loop once suitable block device is found and return the last block devices.
+		// In this case 100GB.
+		if len(prevDataDevices) != 0 && (poolCapacityInt < capacity) {
+			break
+		}
+
+		// maintaining the prevDataDevices that means previous capacity suitable
+		// block devices for requested pool capacity.
+		prevDataDevices = dataDevices
+	}
+
+	poolInstance := types.PoolInstanceConfig{
+		BlockDevices: types.BlockDeviceTopology{
+			DataDevices: prevDataDevices,
+		},
+	}
+
+	return poolInstance
+}
+
 // getOrDefault returns the value from the map for given key.
 // It returns default value if key is absent
-func (ncb nodeCapacityBlockDevice) getOrDefault(key string) capacityBlockDevices {
+func (ncb nodeCapacityBlockDevices) getOrDefault(key string) capacityBlockDevices {
 	value, found := ncb[key]
 	if !found {
 		value = capacityBlockDevices{}
@@ -229,7 +229,7 @@ func (ncb nodeCapacityBlockDevice) getOrDefault(key string) capacityBlockDevices
 }
 
 // updates the map with given key and value
-func (ncb nodeCapacityBlockDevice) update(key string, value capacityBlockDevices) {
+func (ncb nodeCapacityBlockDevices) update(key string, value capacityBlockDevices) {
 	ncb[key] = value
 }
 

--- a/pkg/recommendation/device.go
+++ b/pkg/recommendation/device.go
@@ -1,0 +1,234 @@
+package recommendation
+
+import (
+	"sort"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"mayadata.io/cstorpoolauto/types"
+	bdutil "mayadata.io/cstorpoolauto/util/blockdevice"
+)
+
+type nodeCapacityBlockDevice map[string]capacityBlockDevices
+
+type capacityBlockDevices map[int64][]bdutil.MetaInfo
+
+type cStorPoolClusterRecommendationRequest types.CStorPoolClusterRecommendationRequest
+
+// NewDeviceRequest returns a device request object after validation.
+func NewDeviceRequest(
+	raidConfig *types.RaidGroupConfig, blockDeviceList *unstructured.UnstructuredList, poolCapacity *resource.Quantity) (
+	*cStorPoolClusterRecommendationRequest, error) {
+
+	if raidConfig == nil {
+		return nil, errors.New(
+			"Unable to create device recommendation request: Got nil raid config")
+	}
+	if blockDeviceList == nil {
+		return nil, errors.New(
+			"Unable to create device recommendation request: Got nil block device list")
+	}
+
+	err := raidConfig.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to create capacity recommendation request")
+	}
+
+	return &cStorPoolClusterRecommendationRequest{
+		Spec: types.CStorPoolClusterRecommendationRequestSpec{
+			PoolCapacity:    *poolCapacity,
+			BlockDeviceList: *blockDeviceList,
+			DataConfig:      *raidConfig,
+		},
+	}, nil
+}
+
+// GetRecommendation returns recommended block devices for all nodes and device types.
+func (r cStorPoolClusterRecommendationRequest) GetRecommendation() map[string]types.CStorPoolClusterRecommendation {
+
+	cStorPoolClusterRecommendation := make(map[string]types.CStorPoolClusterRecommendation)
+
+	if len(r.Spec.BlockDeviceList.Items) == 0 {
+		return cStorPoolClusterRecommendation
+	}
+
+	if err := r.Spec.DataConfig.Validate(); err != nil {
+		return cStorPoolClusterRecommendation
+	}
+
+	availableBlockDeviceList := unstructured.UnstructuredList{}
+	availableBlockDeviceList.Object = r.Spec.BlockDeviceList.Object
+	for _, bd := range r.Spec.BlockDeviceList.Items {
+		isEligible, err := bdutil.IsEligibleForCStorPool(bd)
+		if err == nil && isEligible {
+			availableBlockDeviceList.Items = append(availableBlockDeviceList.Items, bd)
+		}
+	}
+	if len(availableBlockDeviceList.Items) == 0 {
+		return cStorPoolClusterRecommendation
+	}
+
+	deviceTypeNodeBlockDeviceMap := bdutil.GetTopologyMapGroupByDeviceTypeAndBlockSize(availableBlockDeviceList)
+	if len(deviceTypeNodeBlockDeviceMap) == 0 {
+		return cStorPoolClusterRecommendation
+	}
+
+	for kind, nodeBlockDeviceListMap := range deviceTypeNodeBlockDeviceMap {
+
+		nodeCapacityBlockDeviceMap := nodeCapacityBlockDevice{}
+
+		// Iterating over nodeBlockDeviceListMap map and populating
+		// nodeCapacityDeviceCountMap
+		for nodeName, blockDeviceList := range nodeBlockDeviceListMap {
+
+			// capacityBlockDevicesMap contains block device capacity and all block devices
+			// of that capacity in one node.
+			capacityBlockDevicesMap := nodeCapacityBlockDeviceMap.getOrDefault(nodeName)
+
+			for _, blockDevice := range blockDeviceList {
+				capacity, found := blockDevice.Capacity.AsInt64()
+				if !found {
+					// TODO handle this case
+					continue
+				}
+
+				blockDevices := capacityBlockDevicesMap.getOrDefault(capacity)
+				capacityBlockDevicesMap.update(capacity, append(blockDevices, blockDevice))
+
+			}
+
+			// update nodeCapacityBlockDeviceMap for each node.
+			nodeCapacityBlockDeviceMap.update(nodeName, capacityBlockDevicesMap)
+		}
+
+		cStorPoolClusterRecommendation[kind] = nodeCapacityBlockDeviceMap.getDeviceRecommendtion(r.Spec.PoolCapacity, r.Spec.DataConfig)
+		cStorPoolClusterRecommendationValue := cStorPoolClusterRecommendation[kind]
+		cStorPoolClusterRecommendationValue.ObjectMeta = r.ObjectMeta
+		cStorPoolClusterRecommendationValue.RequestSpec = r.Spec
+		cStorPoolClusterRecommendation[kind] = cStorPoolClusterRecommendationValue
+	}
+
+	return cStorPoolClusterRecommendation
+}
+
+// getDeviceRecommendtion returns the recommended block devices on a node with the given configuration.
+func (ncb nodeCapacityBlockDevice) getDeviceRecommendtion(poolCapacity resource.Quantity, raidConfig types.RaidGroupConfig) types.CStorPoolClusterRecommendation {
+
+	poolCapacityInt, ok := poolCapacity.AsInt64()
+	if !ok {
+		return types.CStorPoolClusterRecommendation{}
+	}
+
+	poolInstances := []types.PoolInstanceConfig{}
+
+	for nodeName, capacityBlockDevices := range ncb {
+
+		poolInstance := types.PoolInstanceConfig{
+			Node: types.Reference{
+				Name: nodeName,
+			},
+			Capacity: poolCapacity,
+		}
+
+		// To sort map storing (ascending order) keys in a seperate data structure.
+		// Note: map cannot be sorted.
+		capacityKeys := make([]int64, 0, len(capacityBlockDevices))
+		for capacity := range capacityBlockDevices {
+			capacityKeys = append(capacityKeys, capacity)
+		}
+		sort.SliceStable(capacityKeys, func(i, j int) bool {
+			return capacityKeys[i] < capacityKeys[j]
+		})
+
+		prevDataDevices := []types.Reference{}
+		for _, capacity := range capacityKeys {
+			dataDevices := []types.Reference{}
+
+			blockDevices := capacityBlockDevices[capacity]
+			count := int64(len(blockDevices))
+
+			if count < raidConfig.GroupDeviceCount {
+				continue
+			}
+
+			noOfRaidGroup := count / raidConfig.GroupDeviceCount
+
+			maxCapacity := noOfRaidGroup * raidConfig.GetDataDeviceCount() * capacity
+
+			// If required pool capacity is greater than the max capacity of
+			// the current block devices then skip this device.
+			if maxCapacity < poolCapacityInt {
+				continue
+			}
+
+			// Calculate the no of block devices to return to user.
+			noOfBlockDevices := (poolCapacityInt / capacity) * raidConfig.GroupDeviceCount
+			if poolCapacityInt < capacity {
+				noOfBlockDevices = raidConfig.GroupDeviceCount
+			}
+			for i := 0; i < int(noOfBlockDevices); i++ {
+				dataDevices = append(dataDevices, *blockDevices[i].Identity)
+			}
+
+			// Lets say someone requested for a 100GB pool with mirror type and the node
+			// contains both 50GB and 100GB of block devices.
+			// This will break the loop once suitable block device is found and return the last block devices.
+			// In this case 100GB.
+			if len(prevDataDevices) != 0 && (poolCapacityInt < capacity) {
+				break
+			}
+
+			// maintaining the prevDataDevices that means previous capacity suitable
+			// block devices for requested pool capacity.
+			prevDataDevices = dataDevices
+		}
+
+		poolInstance.BlockDevices = types.BlockDeviceTopology{
+			DataDevices: prevDataDevices,
+		}
+		poolInstances = append(poolInstances, poolInstance)
+
+	}
+
+	CStorPoolClusterRecommendation := types.CStorPoolClusterRecommendation{
+		Spec: types.CStorPoolClusterRecommendationSpec{
+			PoolInstances: poolInstances,
+		},
+	}
+
+	return CStorPoolClusterRecommendation
+}
+
+// getOrDefault returns the value from the map for given key.
+// It returns default value if key is absent
+func (ncb nodeCapacityBlockDevice) getOrDefault(key string) capacityBlockDevices {
+	value, found := ncb[key]
+	if !found {
+		value = capacityBlockDevices{}
+		ncb[key] = value
+	}
+	return value
+}
+
+// updates the map with given key and value
+func (ncb nodeCapacityBlockDevice) update(key string, value capacityBlockDevices) {
+	ncb[key] = value
+}
+
+// getOrDefault returns the value from the map for given key.
+// It returns default value if key is absent
+func (cbd capacityBlockDevices) getOrDefault(key int64) []bdutil.MetaInfo {
+	value, found := cbd[key]
+	if !found {
+		value = make([]bdutil.MetaInfo, 0)
+		cbd[key] = value
+	}
+	return value
+}
+
+// updates the map with given key and value
+func (cbd capacityBlockDevices) update(key int64, value []bdutil.MetaInfo) {
+	cbd[key] = value
+}

--- a/pkg/recommendation/device.go
+++ b/pkg/recommendation/device.go
@@ -11,8 +11,11 @@ import (
 	bdutil "mayadata.io/cstorpoolauto/util/blockdevice"
 )
 
+// nodeCapacityBlockDevice contains key with node name and value with capacityBlockDevice
 type nodeCapacityBlockDevice map[string]capacityBlockDevices
 
+// capacityBlockDevices contains a key with capacity of block device and
+// value with all the block devices of that capacity.
 type capacityBlockDevices map[int64][]bdutil.MetaInfo
 
 type cStorPoolClusterRecommendationRequest types.CStorPoolClusterRecommendationRequest
@@ -79,8 +82,6 @@ func (r cStorPoolClusterRecommendationRequest) GetRecommendation() map[string]ty
 
 		nodeCapacityBlockDeviceMap := nodeCapacityBlockDevice{}
 
-		// Iterating over nodeBlockDeviceListMap map and populating
-		// nodeCapacityDeviceCountMap
 		for nodeName, blockDeviceList := range nodeBlockDeviceListMap {
 
 			// capacityBlockDevicesMap contains block device capacity and all block devices

--- a/pkg/recommendation/device_test.go
+++ b/pkg/recommendation/device_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestGetRecommendation(t *testing.T) {
+	poolCapacity100GB, _ := resource.ParseQuantity(fmt.Sprintf("107374182400"))
 	poolCapacity, _ := resource.ParseQuantity(fmt.Sprintf("53687091200"))
 	var tests = map[string]struct {
 		request  cStorPoolClusterRecommendationRequest
@@ -583,7 +584,7 @@ func TestGetRecommendation(t *testing.T) {
 								Node: types.Reference{
 									Name: "node-1",
 								},
-								Capacity: poolCapacity,
+								Capacity: poolCapacity100GB,
 								BlockDevices: types.BlockDeviceTopology{
 									DataDevices: []types.Reference{
 										{

--- a/pkg/recommendation/device_test.go
+++ b/pkg/recommendation/device_test.go
@@ -506,7 +506,7 @@ func TestNewRequestForDevice(t *testing.T) {
 
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, err := NewRequestForDevice(mock.src)
+			_, err := NewRequestForDevice(&mock.src)
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}

--- a/pkg/recommendation/device_test.go
+++ b/pkg/recommendation/device_test.go
@@ -1,0 +1,519 @@
+package recommendation
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+)
+
+func TestGetRecommendation(t *testing.T) {
+	poolCapacity, _ := resource.ParseQuantity(fmt.Sprintf("53687091200"))
+	var tests = map[string]struct {
+		request  cStorPoolClusterRecommendationRequest
+		response map[string]types.CStorPoolClusterRecommendation
+		isErr    bool
+	}{
+		"empty blockdevice list": {
+			request: cStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity:    poolCapacity,
+					BlockDeviceList: unstructured.UnstructuredList{},
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeMirror,
+						GroupDeviceCount: 2,
+					},
+				},
+			},
+			response: make(map[string]types.CStorPoolClusterRecommendation),
+		},
+		"invalid DataConfig": {
+			request: cStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: poolCapacity,
+					BlockDeviceList: unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name": "bd-1",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(53687091200),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+						},
+					},
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeMirror,
+						GroupDeviceCount: 1,
+					},
+				},
+			},
+			response: make(map[string]types.CStorPoolClusterRecommendation),
+		},
+		"zero available block devices": {
+			request: cStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: poolCapacity,
+					BlockDeviceList: unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name": "bd-1",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(53687091200),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceInactive),
+									},
+								},
+							},
+						},
+					},
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeMirror,
+						GroupDeviceCount: 2,
+					},
+				},
+			},
+			response: make(map[string]types.CStorPoolClusterRecommendation),
+		},
+		"missing node name in bd": {
+			request: cStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: poolCapacity,
+					BlockDeviceList: unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name": "bd-1",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(53687091200),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "",
+										},
+										"nodeAttributes": map[string]interface{}{},
+										"filesystem":     map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+						},
+					},
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeMirror,
+						GroupDeviceCount: 2,
+					},
+				},
+			},
+			response: make(map[string]types.CStorPoolClusterRecommendation),
+		},
+		"valid request and response": {
+			request: cStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: poolCapacity,
+					BlockDeviceList: unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-1",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(53687091200),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-2",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(53687091200),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+						},
+					},
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeMirror,
+						GroupDeviceCount: 2,
+					},
+				},
+			},
+			response: map[string]types.CStorPoolClusterRecommendation{
+				"HDD": {
+					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						BlockDeviceList: unstructured.UnstructuredList{
+							Items: []unstructured.Unstructured{
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-1",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(53687091200),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-2",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(53687091200),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+							},
+						},
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 2,
+						},
+					},
+					Spec: types.CStorPoolClusterRecommendationSpec{
+						PoolInstances: []types.PoolInstanceConfig{
+							{
+								Node: types.Reference{
+									Name: "node-1",
+								},
+								Capacity: poolCapacity,
+								BlockDevices: types.BlockDeviceTopology{
+									DataDevices: []types.Reference{
+										{
+											Name:       "bd-1",
+											Namespace:  "openebs",
+											Kind:       "BlockDevice",
+											APIVersion: "openebs.io/v1alpha1",
+											UID:        "",
+										},
+										{
+											Name:       "bd-2",
+											Namespace:  "openebs",
+											Kind:       "BlockDevice",
+											APIVersion: "openebs.io/v1alpha1",
+											UID:        "",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			response := mock.request.GetRecommendation()
+			// if name == "invalid DataConfig" {
+			// 	t.Fatalf("Response - [%+v] - [%+v]\n", response, mock.request)
+			// }
+			if !reflect.DeepEqual(response, mock.response) {
+				t.Fatalf("Expected [%+v] response got [%+v]", mock.response, response)
+			}
+		})
+	}
+}
+
+func TestNewRequestForDevice(t *testing.T) {
+	poolCapacity, _ := resource.ParseQuantity(fmt.Sprintf("53687091200"))
+	var tests = map[string]struct {
+		src   Data
+		isErr bool
+	}{
+		"nil RaidConfig": {
+			src: Data{
+				RaidConfig: nil,
+			},
+			isErr: true,
+		},
+		"nil PoolCapacity": {
+			src: Data{
+				RaidConfig: &types.RaidGroupConfig{
+					Type:             types.PoolRAIDTypeMirror,
+					GroupDeviceCount: 2,
+				},
+				PoolCapacity: nil,
+			},
+			isErr: true,
+		},
+		"nil BlockDeviceList": {
+			src: Data{
+				RaidConfig: &types.RaidGroupConfig{
+					Type:             types.PoolRAIDTypeMirror,
+					GroupDeviceCount: 2,
+				},
+				PoolCapacity:    &poolCapacity,
+				BlockDeviceList: nil,
+			},
+			isErr: true,
+		},
+		"invalid RaidConfig": {
+			src: Data{
+				RaidConfig: &types.RaidGroupConfig{
+					Type:             types.PoolRAIDTypeMirror,
+					GroupDeviceCount: 0,
+				},
+				PoolCapacity: &poolCapacity,
+				BlockDeviceList: &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"apiVersion": "openebs.io/v1alpha1",
+								"kind":       string(types.KindBlockDevice),
+								"metadata": map[string]interface{}{
+									"name": "bd-1",
+									"labels": map[string]interface{}{
+										"kubernetes.io/hostname":  "node-1",
+										"ndm.io/managed":          "false",
+										"ndm.io/blockdevice-type": "blockdevice",
+									},
+								},
+								"spec": map[string]interface{}{
+									"capacity": map[string]interface{}{
+										"storage":            int64(53687091200),
+										"physicalSectorSize": int32(512),
+										"logicalSectorSize":  int32(512),
+									},
+									"details": map[string]interface{}{
+										"deviceType": "",
+									},
+									"nodeAttributes": map[string]interface{}{
+										"nodeName": "node-1",
+									},
+									"filesystem": map[string]interface{}{},
+								},
+								"status": map[string]interface{}{
+									"claimState": string("Unclaimed"),
+									"state":      string(types.BlockDeviceActive),
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"valid case": {
+			src: Data{
+				RaidConfig: &types.RaidGroupConfig{
+					Type:             types.PoolRAIDTypeMirror,
+					GroupDeviceCount: 2,
+				},
+				PoolCapacity: &poolCapacity,
+				BlockDeviceList: &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"apiVersion": "openebs.io/v1alpha1",
+								"kind":       string(types.KindBlockDevice),
+								"metadata": map[string]interface{}{
+									"name": "bd-1",
+									"labels": map[string]interface{}{
+										"kubernetes.io/hostname":  "node-1",
+										"ndm.io/managed":          "false",
+										"ndm.io/blockdevice-type": "blockdevice",
+									},
+								},
+								"spec": map[string]interface{}{
+									"capacity": map[string]interface{}{
+										"storage":            int64(53687091200),
+										"physicalSectorSize": int32(512),
+										"logicalSectorSize":  int32(512),
+									},
+									"details": map[string]interface{}{
+										"deviceType": "",
+									},
+									"nodeAttributes": map[string]interface{}{
+										"nodeName": "node-1",
+									},
+									"filesystem": map[string]interface{}{},
+								},
+								"status": map[string]interface{}{
+									"claimState": string("Unclaimed"),
+									"state":      string(types.BlockDeviceActive),
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+	}
+
+	for name, mock := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewRequestForDevice(mock.src)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+		})
+	}
+
+}

--- a/pkg/recommendation/device_test.go
+++ b/pkg/recommendation/device_test.go
@@ -396,30 +396,7 @@ func TestGetRecommendation(t *testing.T) {
 					},
 				},
 			},
-			response: map[string]types.CStorPoolClusterRecommendation{
-				"HDD": {
-					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
-						PoolCapacity: poolCapacity,
-						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeRAIDZ,
-							GroupDeviceCount: 3,
-						},
-					},
-					Spec: types.CStorPoolClusterRecommendationSpec{
-						PoolInstances: []types.PoolInstanceConfig{
-							{
-								Node: types.Reference{
-									Name: "node-1",
-								},
-								Capacity: poolCapacity,
-								BlockDevices: types.BlockDeviceTopology{
-									DataDevices: []types.Reference{},
-								},
-							},
-						},
-					},
-				},
-			},
+			response: map[string]types.CStorPoolClusterRecommendation{},
 		},
 		"poolCapacity is greater than max capacity in node": {
 			request: cStorPoolClusterRecommendationRequest{
@@ -505,30 +482,7 @@ func TestGetRecommendation(t *testing.T) {
 					},
 				},
 			},
-			response: map[string]types.CStorPoolClusterRecommendation{
-				"HDD": {
-					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
-						PoolCapacity: poolCapacity,
-						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
-							GroupDeviceCount: 2,
-						},
-					},
-					Spec: types.CStorPoolClusterRecommendationSpec{
-						PoolInstances: []types.PoolInstanceConfig{
-							{
-								Node: types.Reference{
-									Name: "node-1",
-								},
-								Capacity: poolCapacity,
-								BlockDevices: types.BlockDeviceTopology{
-									DataDevices: []types.Reference{},
-								},
-							},
-						},
-					},
-				},
-			},
+			response: map[string]types.CStorPoolClusterRecommendation{},
 		},
 		"poolCapacity is less than blockdevice capacity": {
 			request: cStorPoolClusterRecommendationRequest{
@@ -860,21 +814,26 @@ func TestNewRequestForDevice(t *testing.T) {
 	// zeroPoolCapacity, _ := resource.ParseQuantity(fmt.Sprintf("0"))
 	poolCapacity, _ := resource.ParseQuantity(fmt.Sprintf("53687091200"))
 	var tests = map[string]struct {
-		request types.CStorPoolClusterRecommendationRequest
-		data    Data
+		request *types.CStorPoolClusterRecommendationRequest
+		data    *Data
 		isErr   bool
 	}{
+		"nil request": {
+			request: nil,
+			data:    &Data{},
+			isErr:   true,
+		},
 		"nil PoolCapacity": {
-			request: types.CStorPoolClusterRecommendationRequest{
+			request: &types.CStorPoolClusterRecommendationRequest{
 				Spec: types.CStorPoolClusterRecommendationRequestSpec{
 					PoolCapacity: resource.Quantity{},
 				},
 			},
-			data:  Data{},
+			data:  &Data{},
 			isErr: true,
 		},
 		"nil BlockDeviceList": {
-			request: types.CStorPoolClusterRecommendationRequest{
+			request: &types.CStorPoolClusterRecommendationRequest{
 				Spec: types.CStorPoolClusterRecommendationRequestSpec{
 					PoolCapacity: poolCapacity,
 					DataConfig: types.RaidGroupConfig{
@@ -883,13 +842,13 @@ func TestNewRequestForDevice(t *testing.T) {
 					},
 				},
 			},
-			data: Data{
+			data: &Data{
 				BlockDeviceList: nil,
 			},
 			isErr: true,
 		},
 		"invalid RaidConfig": {
-			request: types.CStorPoolClusterRecommendationRequest{
+			request: &types.CStorPoolClusterRecommendationRequest{
 				Spec: types.CStorPoolClusterRecommendationRequestSpec{
 					PoolCapacity: poolCapacity,
 					DataConfig: types.RaidGroupConfig{
@@ -898,7 +857,7 @@ func TestNewRequestForDevice(t *testing.T) {
 					},
 				},
 			},
-			data: Data{
+			data: &Data{
 				BlockDeviceList: &unstructured.UnstructuredList{
 					Items: []unstructured.Unstructured{
 						{
@@ -939,7 +898,7 @@ func TestNewRequestForDevice(t *testing.T) {
 			isErr: true,
 		},
 		"valid case": {
-			request: types.CStorPoolClusterRecommendationRequest{
+			request: &types.CStorPoolClusterRecommendationRequest{
 				Spec: types.CStorPoolClusterRecommendationRequestSpec{
 					PoolCapacity: poolCapacity,
 					DataConfig: types.RaidGroupConfig{
@@ -948,7 +907,7 @@ func TestNewRequestForDevice(t *testing.T) {
 					},
 				},
 			},
-			data: Data{
+			data: &Data{
 				BlockDeviceList: &unstructured.UnstructuredList{
 					Items: []unstructured.Unstructured{
 						{
@@ -992,7 +951,7 @@ func TestNewRequestForDevice(t *testing.T) {
 
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, err := NewRequestForDevice(&mock.request, &mock.data)
+			_, err := NewRequestForDevice(mock.request, mock.data)
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}

--- a/pkg/recommendation/device_test.go
+++ b/pkg/recommendation/device_test.go
@@ -362,6 +362,868 @@ func TestGetRecommendation(t *testing.T) {
 				},
 			},
 		},
+		"blockdevices count is less than group device count": {
+			request: cStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: poolCapacity,
+					BlockDeviceList: unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-1",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(53687091200),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-2",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(53687091200),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+						},
+					},
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeRAIDZ,
+						GroupDeviceCount: 3,
+					},
+				},
+			},
+			response: map[string]types.CStorPoolClusterRecommendation{
+				"HDD": {
+					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						BlockDeviceList: unstructured.UnstructuredList{
+							Items: []unstructured.Unstructured{
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-1",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(53687091200),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-2",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(53687091200),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+							},
+						},
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeRAIDZ,
+							GroupDeviceCount: 3,
+						},
+					},
+					Spec: types.CStorPoolClusterRecommendationSpec{
+						PoolInstances: []types.PoolInstanceConfig{
+							{
+								Node: types.Reference{
+									Name: "node-1",
+								},
+								Capacity: poolCapacity,
+								BlockDevices: types.BlockDeviceTopology{
+									DataDevices: []types.Reference{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"poolCapacity is greater than max capacity in node": {
+			request: cStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: poolCapacity,
+					BlockDeviceList: unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-1",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(5368709120),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-2",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(5368709120),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+						},
+					},
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeMirror,
+						GroupDeviceCount: 2,
+					},
+				},
+			},
+			response: map[string]types.CStorPoolClusterRecommendation{
+				"HDD": {
+					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						BlockDeviceList: unstructured.UnstructuredList{
+							Items: []unstructured.Unstructured{
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-1",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(5368709120),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-2",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(5368709120),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+							},
+						},
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 2,
+						},
+					},
+					Spec: types.CStorPoolClusterRecommendationSpec{
+						PoolInstances: []types.PoolInstanceConfig{
+							{
+								Node: types.Reference{
+									Name: "node-1",
+								},
+								Capacity: poolCapacity,
+								BlockDevices: types.BlockDeviceTopology{
+									DataDevices: []types.Reference{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"poolCapacity is less than blockdevice capacity": {
+			request: cStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: poolCapacity,
+					BlockDeviceList: unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-1",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(107374182400),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-2",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(107374182400),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+						},
+					},
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeMirror,
+						GroupDeviceCount: 2,
+					},
+				},
+			},
+			response: map[string]types.CStorPoolClusterRecommendation{
+				"HDD": {
+					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						BlockDeviceList: unstructured.UnstructuredList{
+							Items: []unstructured.Unstructured{
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-1",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(107374182400),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-2",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(107374182400),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+							},
+						},
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 2,
+						},
+					},
+					Spec: types.CStorPoolClusterRecommendationSpec{
+						PoolInstances: []types.PoolInstanceConfig{
+							{
+								Node: types.Reference{
+									Name: "node-1",
+								},
+								Capacity: poolCapacity,
+								BlockDevices: types.BlockDeviceTopology{
+									DataDevices: []types.Reference{
+										{
+											Name:       "bd-1",
+											Namespace:  "openebs",
+											Kind:       "BlockDevice",
+											APIVersion: "openebs.io/v1alpha1",
+											UID:        "",
+										},
+										{
+											Name:       "bd-2",
+											Namespace:  "openebs",
+											Kind:       "BlockDevice",
+											APIVersion: "openebs.io/v1alpha1",
+											UID:        "",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"multiple size suitable blockdevices": {
+			request: cStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: poolCapacity,
+					BlockDeviceList: unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-1",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(53687091200),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-2",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(53687091200),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-3",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(107374182400),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"apiVersion": "openebs.io/v1alpha1",
+									"kind":       string(types.KindBlockDevice),
+									"metadata": map[string]interface{}{
+										"name":      "bd-4",
+										"namespace": "openebs",
+										"labels": map[string]interface{}{
+											"kubernetes.io/hostname":  "node-1",
+											"ndm.io/managed":          "false",
+											"ndm.io/blockdevice-type": "blockdevice",
+										},
+									},
+									"spec": map[string]interface{}{
+										"capacity": map[string]interface{}{
+											"storage":            int64(107374182400),
+											"physicalSectorSize": int32(512),
+											"logicalSectorSize":  int32(512),
+										},
+										"details": map[string]interface{}{
+											"deviceType": "HDD",
+										},
+										"nodeAttributes": map[string]interface{}{
+											"nodeName": "node-1",
+										},
+										"filesystem": map[string]interface{}{},
+									},
+									"status": map[string]interface{}{
+										"claimState": string("Unclaimed"),
+										"state":      string(types.BlockDeviceActive),
+									},
+								},
+							},
+						},
+					},
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeMirror,
+						GroupDeviceCount: 2,
+					},
+				},
+			},
+			response: map[string]types.CStorPoolClusterRecommendation{
+				"HDD": {
+					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						BlockDeviceList: unstructured.UnstructuredList{
+							Items: []unstructured.Unstructured{
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-1",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(53687091200),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-2",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(53687091200),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-3",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(107374182400),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+								{
+									Object: map[string]interface{}{
+										"apiVersion": "openebs.io/v1alpha1",
+										"kind":       string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "bd-4",
+											"namespace": "openebs",
+											"labels": map[string]interface{}{
+												"kubernetes.io/hostname":  "node-1",
+												"ndm.io/managed":          "false",
+												"ndm.io/blockdevice-type": "blockdevice",
+											},
+										},
+										"spec": map[string]interface{}{
+											"capacity": map[string]interface{}{
+												"storage":            int64(107374182400),
+												"physicalSectorSize": int32(512),
+												"logicalSectorSize":  int32(512),
+											},
+											"details": map[string]interface{}{
+												"deviceType": "HDD",
+											},
+											"nodeAttributes": map[string]interface{}{
+												"nodeName": "node-1",
+											},
+											"filesystem": map[string]interface{}{},
+										},
+										"status": map[string]interface{}{
+											"claimState": string("Unclaimed"),
+											"state":      string(types.BlockDeviceActive),
+										},
+									},
+								},
+							},
+						},
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 2,
+						},
+					},
+					Spec: types.CStorPoolClusterRecommendationSpec{
+						PoolInstances: []types.PoolInstanceConfig{
+							{
+								Node: types.Reference{
+									Name: "node-1",
+								},
+								Capacity: poolCapacity,
+								BlockDevices: types.BlockDeviceTopology{
+									DataDevices: []types.Reference{
+										{
+											Name:       "bd-1",
+											Namespace:  "openebs",
+											Kind:       "BlockDevice",
+											APIVersion: "openebs.io/v1alpha1",
+											UID:        "",
+										},
+										{
+											Name:       "bd-2",
+											Namespace:  "openebs",
+											Kind:       "BlockDevice",
+											APIVersion: "openebs.io/v1alpha1",
+											UID:        "",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, mock := range tests {

--- a/pkg/recommendation/device_test.go
+++ b/pkg/recommendation/device_test.go
@@ -19,22 +19,34 @@ func TestGetRecommendation(t *testing.T) {
 	}{
 		"empty blockdevice list": {
 			request: cStorPoolClusterRecommendationRequest{
-				Spec: types.CStorPoolClusterRecommendationRequestSpec{
-					PoolCapacity:    poolCapacity,
-					BlockDeviceList: unstructured.UnstructuredList{},
-					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeMirror,
-						GroupDeviceCount: 2,
+				Request: types.CStorPoolClusterRecommendationRequest{
+					Spec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 2,
+						},
 					},
+				},
+				Data: Data{
+					BlockDeviceList: &unstructured.UnstructuredList{},
 				},
 			},
 			response: make(map[string]types.CStorPoolClusterRecommendation),
 		},
 		"invalid DataConfig": {
 			request: cStorPoolClusterRecommendationRequest{
-				Spec: types.CStorPoolClusterRecommendationRequestSpec{
-					PoolCapacity: poolCapacity,
-					BlockDeviceList: unstructured.UnstructuredList{
+				Request: types.CStorPoolClusterRecommendationRequest{
+					Spec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 1,
+						},
+					},
+				},
+				Data: Data{
+					BlockDeviceList: &unstructured.UnstructuredList{
 						Items: []unstructured.Unstructured{
 							{
 								Object: map[string]interface{}{
@@ -70,19 +82,23 @@ func TestGetRecommendation(t *testing.T) {
 							},
 						},
 					},
-					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeMirror,
-						GroupDeviceCount: 1,
-					},
 				},
 			},
 			response: make(map[string]types.CStorPoolClusterRecommendation),
 		},
 		"zero available block devices": {
 			request: cStorPoolClusterRecommendationRequest{
-				Spec: types.CStorPoolClusterRecommendationRequestSpec{
-					PoolCapacity: poolCapacity,
-					BlockDeviceList: unstructured.UnstructuredList{
+				Request: types.CStorPoolClusterRecommendationRequest{
+					Spec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 2,
+						},
+					},
+				},
+				Data: Data{
+					BlockDeviceList: &unstructured.UnstructuredList{
 						Items: []unstructured.Unstructured{
 							{
 								Object: map[string]interface{}{
@@ -118,19 +134,23 @@ func TestGetRecommendation(t *testing.T) {
 							},
 						},
 					},
-					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeMirror,
-						GroupDeviceCount: 2,
-					},
 				},
 			},
 			response: make(map[string]types.CStorPoolClusterRecommendation),
 		},
 		"missing node name in bd": {
 			request: cStorPoolClusterRecommendationRequest{
-				Spec: types.CStorPoolClusterRecommendationRequestSpec{
-					PoolCapacity: poolCapacity,
-					BlockDeviceList: unstructured.UnstructuredList{
+				Request: types.CStorPoolClusterRecommendationRequest{
+					Spec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 2,
+						},
+					},
+				},
+				Data: Data{
+					BlockDeviceList: &unstructured.UnstructuredList{
 						Items: []unstructured.Unstructured{
 							{
 								Object: map[string]interface{}{
@@ -164,19 +184,23 @@ func TestGetRecommendation(t *testing.T) {
 							},
 						},
 					},
-					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeMirror,
-						GroupDeviceCount: 2,
-					},
 				},
 			},
 			response: make(map[string]types.CStorPoolClusterRecommendation),
 		},
 		"valid request and response": {
 			request: cStorPoolClusterRecommendationRequest{
-				Spec: types.CStorPoolClusterRecommendationRequestSpec{
-					PoolCapacity: poolCapacity,
-					BlockDeviceList: unstructured.UnstructuredList{
+				Request: types.CStorPoolClusterRecommendationRequest{
+					Spec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 2,
+						},
+					},
+				},
+				Data: Data{
+					BlockDeviceList: &unstructured.UnstructuredList{
 						Items: []unstructured.Unstructured{
 							{
 								Object: map[string]interface{}{
@@ -246,86 +270,12 @@ func TestGetRecommendation(t *testing.T) {
 							},
 						},
 					},
-					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeMirror,
-						GroupDeviceCount: 2,
-					},
 				},
 			},
 			response: map[string]types.CStorPoolClusterRecommendation{
 				"HDD": {
 					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
-						BlockDeviceList: unstructured.UnstructuredList{
-							Items: []unstructured.Unstructured{
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-1",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(53687091200),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-2",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(53687091200),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-							},
-						},
 						DataConfig: types.RaidGroupConfig{
 							Type:             types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
@@ -364,9 +314,17 @@ func TestGetRecommendation(t *testing.T) {
 		},
 		"blockdevices count is less than group device count": {
 			request: cStorPoolClusterRecommendationRequest{
-				Spec: types.CStorPoolClusterRecommendationRequestSpec{
-					PoolCapacity: poolCapacity,
-					BlockDeviceList: unstructured.UnstructuredList{
+				Request: types.CStorPoolClusterRecommendationRequest{
+					Spec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeRAIDZ,
+							GroupDeviceCount: 3,
+						},
+					},
+				},
+				Data: Data{
+					BlockDeviceList: &unstructured.UnstructuredList{
 						Items: []unstructured.Unstructured{
 							{
 								Object: map[string]interface{}{
@@ -436,86 +394,12 @@ func TestGetRecommendation(t *testing.T) {
 							},
 						},
 					},
-					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeRAIDZ,
-						GroupDeviceCount: 3,
-					},
 				},
 			},
 			response: map[string]types.CStorPoolClusterRecommendation{
 				"HDD": {
 					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
-						BlockDeviceList: unstructured.UnstructuredList{
-							Items: []unstructured.Unstructured{
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-1",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(53687091200),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-2",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(53687091200),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-							},
-						},
 						DataConfig: types.RaidGroupConfig{
 							Type:             types.PoolRAIDTypeRAIDZ,
 							GroupDeviceCount: 3,
@@ -539,9 +423,17 @@ func TestGetRecommendation(t *testing.T) {
 		},
 		"poolCapacity is greater than max capacity in node": {
 			request: cStorPoolClusterRecommendationRequest{
-				Spec: types.CStorPoolClusterRecommendationRequestSpec{
-					PoolCapacity: poolCapacity,
-					BlockDeviceList: unstructured.UnstructuredList{
+				Request: types.CStorPoolClusterRecommendationRequest{
+					Spec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 2,
+						},
+					},
+				},
+				Data: Data{
+					BlockDeviceList: &unstructured.UnstructuredList{
 						Items: []unstructured.Unstructured{
 							{
 								Object: map[string]interface{}{
@@ -611,86 +503,12 @@ func TestGetRecommendation(t *testing.T) {
 							},
 						},
 					},
-					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeMirror,
-						GroupDeviceCount: 2,
-					},
 				},
 			},
 			response: map[string]types.CStorPoolClusterRecommendation{
 				"HDD": {
 					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
-						BlockDeviceList: unstructured.UnstructuredList{
-							Items: []unstructured.Unstructured{
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-1",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(5368709120),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-2",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(5368709120),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-							},
-						},
 						DataConfig: types.RaidGroupConfig{
 							Type:             types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
@@ -714,9 +532,17 @@ func TestGetRecommendation(t *testing.T) {
 		},
 		"poolCapacity is less than blockdevice capacity": {
 			request: cStorPoolClusterRecommendationRequest{
-				Spec: types.CStorPoolClusterRecommendationRequestSpec{
-					PoolCapacity: poolCapacity,
-					BlockDeviceList: unstructured.UnstructuredList{
+				Request: types.CStorPoolClusterRecommendationRequest{
+					Spec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 2,
+						},
+					},
+				},
+				Data: Data{
+					BlockDeviceList: &unstructured.UnstructuredList{
 						Items: []unstructured.Unstructured{
 							{
 								Object: map[string]interface{}{
@@ -786,86 +612,12 @@ func TestGetRecommendation(t *testing.T) {
 							},
 						},
 					},
-					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeMirror,
-						GroupDeviceCount: 2,
-					},
 				},
 			},
 			response: map[string]types.CStorPoolClusterRecommendation{
 				"HDD": {
 					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
-						BlockDeviceList: unstructured.UnstructuredList{
-							Items: []unstructured.Unstructured{
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-1",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(107374182400),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-2",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(107374182400),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-							},
-						},
 						DataConfig: types.RaidGroupConfig{
 							Type:             types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
@@ -904,9 +656,17 @@ func TestGetRecommendation(t *testing.T) {
 		},
 		"multiple size suitable blockdevices": {
 			request: cStorPoolClusterRecommendationRequest{
-				Spec: types.CStorPoolClusterRecommendationRequestSpec{
-					PoolCapacity: poolCapacity,
-					BlockDeviceList: unstructured.UnstructuredList{
+				Request: types.CStorPoolClusterRecommendationRequest{
+					Spec: types.CStorPoolClusterRecommendationRequestSpec{
+						PoolCapacity: poolCapacity,
+						DataConfig: types.RaidGroupConfig{
+							Type:             types.PoolRAIDTypeMirror,
+							GroupDeviceCount: 2,
+						},
+					},
+				},
+				Data: Data{
+					BlockDeviceList: &unstructured.UnstructuredList{
 						Items: []unstructured.Unstructured{
 							{
 								Object: map[string]interface{}{
@@ -1042,152 +802,12 @@ func TestGetRecommendation(t *testing.T) {
 							},
 						},
 					},
-					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeMirror,
-						GroupDeviceCount: 2,
-					},
 				},
 			},
 			response: map[string]types.CStorPoolClusterRecommendation{
 				"HDD": {
 					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
-						BlockDeviceList: unstructured.UnstructuredList{
-							Items: []unstructured.Unstructured{
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-1",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(53687091200),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-2",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(53687091200),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-3",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(107374182400),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-								{
-									Object: map[string]interface{}{
-										"apiVersion": "openebs.io/v1alpha1",
-										"kind":       string(types.KindBlockDevice),
-										"metadata": map[string]interface{}{
-											"name":      "bd-4",
-											"namespace": "openebs",
-											"labels": map[string]interface{}{
-												"kubernetes.io/hostname":  "node-1",
-												"ndm.io/managed":          "false",
-												"ndm.io/blockdevice-type": "blockdevice",
-											},
-										},
-										"spec": map[string]interface{}{
-											"capacity": map[string]interface{}{
-												"storage":            int64(107374182400),
-												"physicalSectorSize": int32(512),
-												"logicalSectorSize":  int32(512),
-											},
-											"details": map[string]interface{}{
-												"deviceType": "HDD",
-											},
-											"nodeAttributes": map[string]interface{}{
-												"nodeName": "node-1",
-											},
-											"filesystem": map[string]interface{}{},
-										},
-										"status": map[string]interface{}{
-											"claimState": string("Unclaimed"),
-											"state":      string(types.BlockDeviceActive),
-										},
-									},
-								},
-							},
-						},
 						DataConfig: types.RaidGroupConfig{
 							Type:             types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
@@ -1229,9 +849,6 @@ func TestGetRecommendation(t *testing.T) {
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
 			response := mock.request.GetRecommendation()
-			// if name == "invalid DataConfig" {
-			// 	t.Fatalf("Response - [%+v] - [%+v]\n", response, mock.request)
-			// }
 			if !reflect.DeepEqual(response, mock.response) {
 				t.Fatalf("Expected [%+v] response got [%+v]", mock.response, response)
 			}
@@ -1240,45 +857,48 @@ func TestGetRecommendation(t *testing.T) {
 }
 
 func TestNewRequestForDevice(t *testing.T) {
+	// zeroPoolCapacity, _ := resource.ParseQuantity(fmt.Sprintf("0"))
 	poolCapacity, _ := resource.ParseQuantity(fmt.Sprintf("53687091200"))
 	var tests = map[string]struct {
-		src   Data
-		isErr bool
+		request types.CStorPoolClusterRecommendationRequest
+		data    Data
+		isErr   bool
 	}{
-		"nil RaidConfig": {
-			src: Data{
-				RaidConfig: nil,
-			},
-			isErr: true,
-		},
 		"nil PoolCapacity": {
-			src: Data{
-				RaidConfig: &types.RaidGroupConfig{
-					Type:             types.PoolRAIDTypeMirror,
-					GroupDeviceCount: 2,
+			request: types.CStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: resource.Quantity{},
 				},
-				PoolCapacity: nil,
 			},
+			data:  Data{},
 			isErr: true,
 		},
 		"nil BlockDeviceList": {
-			src: Data{
-				RaidConfig: &types.RaidGroupConfig{
-					Type:             types.PoolRAIDTypeMirror,
-					GroupDeviceCount: 2,
+			request: types.CStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: poolCapacity,
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeMirror,
+						GroupDeviceCount: 2,
+					},
 				},
-				PoolCapacity:    &poolCapacity,
+			},
+			data: Data{
 				BlockDeviceList: nil,
 			},
 			isErr: true,
 		},
 		"invalid RaidConfig": {
-			src: Data{
-				RaidConfig: &types.RaidGroupConfig{
-					Type:             types.PoolRAIDTypeMirror,
-					GroupDeviceCount: 0,
+			request: types.CStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: poolCapacity,
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeMirror,
+						GroupDeviceCount: 0,
+					},
 				},
-				PoolCapacity: &poolCapacity,
+			},
+			data: Data{
 				BlockDeviceList: &unstructured.UnstructuredList{
 					Items: []unstructured.Unstructured{
 						{
@@ -1319,12 +939,16 @@ func TestNewRequestForDevice(t *testing.T) {
 			isErr: true,
 		},
 		"valid case": {
-			src: Data{
-				RaidConfig: &types.RaidGroupConfig{
-					Type:             types.PoolRAIDTypeMirror,
-					GroupDeviceCount: 2,
+			request: types.CStorPoolClusterRecommendationRequest{
+				Spec: types.CStorPoolClusterRecommendationRequestSpec{
+					PoolCapacity: poolCapacity,
+					DataConfig: types.RaidGroupConfig{
+						Type:             types.PoolRAIDTypeMirror,
+						GroupDeviceCount: 2,
+					},
 				},
-				PoolCapacity: &poolCapacity,
+			},
+			data: Data{
 				BlockDeviceList: &unstructured.UnstructuredList{
 					Items: []unstructured.Unstructured{
 						{
@@ -1368,7 +992,7 @@ func TestNewRequestForDevice(t *testing.T) {
 
 	for name, mock := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, err := NewRequestForDevice(&mock.src)
+			_, err := NewRequestForDevice(&mock.request, &mock.data)
 			if mock.isErr && err == nil {
 				t.Fatalf("Expected error got none")
 			}

--- a/types/recommendationrequest.go
+++ b/types/recommendationrequest.go
@@ -19,7 +19,6 @@ package types
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // CStorPoolClusterRecommendationRequest is a kubernetes custom
@@ -40,8 +39,6 @@ type CStorPoolClusterRecommendationRequest struct {
 type CStorPoolClusterRecommendationRequestSpec struct {
 	// PoolCapacity represents requested capacity for one pool
 	PoolCapacity resource.Quantity `json:"poolCapacity"`
-	// BlockDeviceList represents list of block devices in all nodes.
-	BlockDeviceList unstructured.UnstructuredList `json:"blockDeviceList"`
 	// DataConfig represents raid configuration for data devices.
 	DataConfig RaidGroupConfig `json:"dataConfig"`
 	// WriteCacheConfig represents raid configuration for write cache devices.

--- a/types/recommendationrequest.go
+++ b/types/recommendationrequest.go
@@ -19,6 +19,7 @@ package types
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // CStorPoolClusterRecommendationRequest is a kubernetes custom
@@ -39,6 +40,8 @@ type CStorPoolClusterRecommendationRequest struct {
 type CStorPoolClusterRecommendationRequestSpec struct {
 	// PoolCapacity represents requested capacity for one pool
 	PoolCapacity resource.Quantity `json:"poolCapacity"`
+	// BlockDeviceList represents list of block devices in all nodes.
+	BlockDeviceList unstructured.UnstructuredList `json:"blockDeviceList"`
 	// DataConfig represents raid configuration for data devices.
 	DataConfig RaidGroupConfig `json:"dataConfig"`
 	// WriteCacheConfig represents raid configuration for write cache devices.

--- a/util/blockdevice/topology.go
+++ b/util/blockdevice/topology.go
@@ -81,7 +81,7 @@ func GetTopologyMapGroupByDeviceTypeAndBlockSize(
 
 	for _, bd := range bdList.Items {
 
-		// Block device should be associated with a node if mode name is missing or
+		// Block device should be associated with a node if node name is missing or
 		// we got any error during fetching node name then we can not use that to
 		// create topology map.
 		nodeName, err := GetNodeNameOrError(bd)


### PR DESCRIPTION
This PR adds support to get device recommendations for given configurations.

This adds a logic to recommend blockdevices for creating a cstor pool. It accepts the parameters for recommendation like poolCapacity which is the requested pool capacity and raidConfig which is the requested raid type (stripe, mirror, raidz, raidz2) for creating cStor pool. It also requires list of blockdevices as an input. It returns the recommended blockdevices in each node for each device type (HDD, SSD, etc).

Client code: 
```
        raidconfig := &types.RaidGroupConfig{
		Type:             types.PoolRAIDType("mirror"),
		GroupDeviceCount: 2,
	}

	if err := raidconfig.PopulateDefaultGroupDeviceCountIfNotPresent(); err != nil {
		raidconfig = types.GetDefaultRaidGroupConfig()
	}

	if err := raidconfig.Validate(); err != nil {
		raidconfig = types.GetDefaultRaidGroupConfig()
	}

        // poolCapacity is the requested capacity.
	poolCapacity, err := resource.ParseQuantity(fmt.Sprintf("53687091200"))

        // csprr contains the parameter requested for cstor pool where poolcapacity
        // is the requested pool capacity and dataconfig is the requested type of pool.
        csprr := types.CStorPoolClusterRecommendationRequest{
		Spec: types.CStorPoolClusterRecommendationRequestSpec{
			PoolCapacity: poolCapacity,
			DataConfig:   *raidconfig,
		},
	}
       
        // This will contain the data required for recommendation.
        inputData := recommendation.Data{
		BlockDeviceList: list,
	}
        
	deviceRequest, err := recommendation.NewRequestForDevice(&csprr, &inputData)
         
        // cStorPoolClusterRecommendation will contain the list of recommended
        // blockdevices in each node for each device type.
	cStorPoolClusterRecommendation := deviceRequest.GetRecommendation()
```

Signed-off-by: Sumit Lalwani <sumit.lalwani97@gmail.com>
