### PR TITLE
feat(local): add local disk based cstor pool auto provisioning

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"mayadata.io/cstorpoolauto/controller/cstorclusterplan"
 	"mayadata.io/cstorpoolauto/controller/cstorclusterstorageset"
 	"mayadata.io/cstorpoolauto/controller/cstorpoolcluster"
+	"mayadata.io/cstorpoolauto/controller/localdevice"
 )
 
 // main function is the entry point of this binary.
@@ -47,6 +48,7 @@ func main() {
 	generic.AddToInlineRegistry("sync/cstorclusterstorageset", cstorclusterstorageset.Sync)
 	generic.AddToInlineRegistry("sync/blockdevice", blockdevice.Sync)
 	generic.AddToInlineRegistry("sync/cstorpoolcluster", cstorpoolcluster.Sync)
+	generic.AddToInlineRegistry("sync/localdevice", localdevice.Sync)
 
 	start.Start()
 }

--- a/controller/cstorpoolcluster/reconciler.go
+++ b/controller/cstorpoolcluster/reconciler.go
@@ -474,6 +474,9 @@ func (p *Planner) initStorageSetToObservedBlockDevices() error {
 
 // initNodeToObservedCSPCDevices maps node name to observed
 // devices in the same order they are observed in CStorPoolCluster
+//
+// TODO:
+//	Make use of util/cstorpoolcluster/helper methods
 func (p *Planner) initNodeToObservedCSPCDevices() error {
 	// currentNodeName holds the current node name of the
 	// CStorPoolCluster nodes that are under iteration
@@ -646,6 +649,8 @@ func (p *Planner) buildDesiredPools() []interface{} {
 	return pools
 }
 
+// TODO (@amitkumardas):
+//  Make use of util/cstorpoolcluster/builder.go methods
 func (p *Planner) getDesiredCStorPoolCluster() *unstructured.Unstructured {
 	cspc := &unstructured.Unstructured{}
 	cspc.SetUnstructuredContent(map[string]interface{}{

--- a/controller/localdevice/reconciler.go
+++ b/controller/localdevice/reconciler.go
@@ -1,0 +1,402 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localdevice
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	metac "openebs.io/metac/apis/metacontroller/v1alpha1"
+	"openebs.io/metac/controller/generic"
+
+	"mayadata.io/cstorpoolauto/types"
+	"mayadata.io/cstorpoolauto/unstruct"
+	bd "mayadata.io/cstorpoolauto/util/blockdevice"
+	ccc "mayadata.io/cstorpoolauto/util/cstorclusterconfig"
+	cspc "mayadata.io/cstorpoolauto/util/cstorpoolcluster"
+	metacutil "mayadata.io/cstorpoolauto/util/metac"
+)
+
+type syncer struct {
+	request  *generic.SyncHookRequest
+	response *generic.SyncHookResponse
+
+	blockDevices     []*unstructured.Unstructured
+	cstorPoolCluster *unstructured.Unstructured
+
+	reconcileResponse ReconcileResponse
+	isDiskLocal       bool
+	fatal             error
+	err               error
+	warns             []string
+}
+
+func (s *syncer) validateArgs() {
+	// validation failure of request &/ response is a fatal error
+	s.fatal = metacutil.ValidateGenericControllerArgs(s.request, s.response)
+}
+
+func (s *syncer) skipIfNotLocalDisk() {
+	s.isDiskLocal, s.err =
+		ccc.NewHelper(s.request.Watch).IsLocalBlockDiskConfig()
+	if s.err != nil {
+		return
+	}
+	if !s.isDiskLocal {
+		var msg = fmt.Sprintf(
+			"Will skip LocalDevice sync: DiskConfig is not local: Watch %q - %q / %q",
+			s.request.Watch.GetKind(),
+			s.request.Watch.GetNamespace(),
+			s.request.Watch.GetName(),
+		)
+		glog.V(3).Infof(msg)
+		s.response.SkipReconcile = true
+	}
+}
+
+func (s *syncer) skipIfEmptyAttachments() {
+	// Nothing needs to be done if there are no attachments in request
+	//
+	// NOTE:
+	// 	It is expected to have BlockDevices as attachments
+	if s.request.Attachments == nil || s.request.Attachments.IsEmpty() {
+		var msg = fmt.Sprintf(
+			"Will skip LocalDevice sync: Nil attachments: Watch %q - %q / %q",
+			s.request.Watch.GetKind(),
+			s.request.Watch.GetNamespace(),
+			s.request.Watch.GetName(),
+		)
+		glog.V(3).Infof(msg)
+		s.response.SkipReconcile = true
+	}
+}
+
+func (s *syncer) logSyncStart() {
+	glog.V(3).Infof(
+		"Started LocalDevice sync: Watch %q - %q / %q",
+		s.request.Watch.GetKind(),
+		s.request.Watch.GetNamespace(),
+		s.request.Watch.GetName(),
+	)
+}
+
+func (s *syncer) registerAttachments() {
+	// TODO (@amitkumardas):
+	// Make use of unstruct list selector
+	// Introduce callback feature to grab blockdevices
+	// & cspc separately
+	for _, attachment := range s.request.Attachments.List() {
+		// we are interested for BlockDevices attachments only
+		if attachment.GetKind() == string(types.KindBlockDevice) {
+			s.blockDevices = append(s.blockDevices, attachment)
+		}
+		if attachment.GetKind() == string(types.KindCStorPoolCluster) {
+			uid, _ := unstruct.GetValueForKey(
+				attachment.GetAnnotations(), types.AnnKeyCStorClusterConfigUID,
+			)
+			if string(s.request.Watch.GetUID()) == uid {
+				s.cstorPoolCluster = attachment
+				// don't add cspc to response now
+				//
+				// NOTE:
+				// 	cspc is added to reponse after completing reconciliation
+				continue
+			}
+		}
+		s.response.Attachments = append(s.response.Attachments, attachment)
+	}
+}
+
+func (s *syncer) reconcile() {
+	// reconciler performs reconciliation of CStorClusterConfig
+	reconciler := &Reconciler{
+		ObservedCStorClusterConfig: s.request.Watch,
+		ObservedBlockDevices:       s.blockDevices,
+		ObservedCStorPoolCluster:   s.cstorPoolCluster,
+	}
+	s.reconcileResponse, s.err = reconciler.Reconcile()
+	if s.err != nil {
+		return
+	}
+	if s.reconcileResponse.SkipReconcile {
+		// skip reconciliation at metac
+		s.response.SkipReconcile = true
+		glog.V(3).Infof(
+			"Will skip LocalDevice sync: Reason %s: Watch %q - %q / %q",
+			s.reconcileResponse.SkipReason,
+			s.request.Watch.GetKind(),
+			s.request.Watch.GetNamespace(),
+			s.request.Watch.GetName(),
+		)
+		return
+	}
+	// add desired CStorPoolCluster to response
+	s.response.Attachments = append(
+		s.response.Attachments, s.reconcileResponse.CStorPoolCluster,
+	)
+}
+
+func (s *syncer) logSyncFinish() {
+	glog.V(2).Infof(
+		"Finished LocalDevice sync: Watch %q - %q / %q: %s",
+		s.request.Watch.GetKind(),
+		s.request.Watch.GetNamespace(),
+		s.request.Watch.GetName(),
+		metacutil.GetDetailsFromResponse(s.response),
+	)
+}
+
+// handleError logs the error if any
+func (s *syncer) handleError() {
+	if s.err == nil {
+		// nothing to do if there was no error
+		return
+	}
+	// log this error with context
+	glog.Errorf(
+		"Failed to sync LocalDevice: Watch %q - %q / %q: %+v",
+		s.request.Watch.GetKind(),
+		s.request.Watch.GetNamespace(),
+		s.request.Watch.GetName(),
+		s.err,
+	)
+	// stop further reconciliation at metac since there was an error
+	s.response.SkipReconcile = true
+}
+
+func (s *syncer) sync() error {
+	fns := []func(){
+		s.validateArgs,
+		s.skipIfNotLocalDisk,
+		s.skipIfEmptyAttachments,
+		s.logSyncStart,
+		s.registerAttachments,
+		s.reconcile,
+		s.logSyncFinish,
+	}
+	for _, fn := range fns {
+		fn()
+		// post operation checks
+		if s.fatal != nil {
+			return s.fatal
+		}
+		if s.err != nil {
+			// this logs the error thus avoiding panic in the
+			// controller
+			s.handleError()
+		}
+		if s.response.SkipReconcile {
+			return nil
+		}
+	}
+	return nil
+}
+
+// Sync implements the idempotent logic to sync CStorClusterConfig
+//
+// NOTE:
+// 	SyncHookRequest is the payload received as part of reconcile
+// request. Similarly, SyncHookResponse is the payload sent as a
+// response as part of reconcile request.
+//
+// NOTE:
+//	SyncHookRequest uses CStorClusterConfig as the watched resource.
+// SyncHookResponse has the resources that forms the desired state
+// w.r.t the watched resource.
+//
+// NOTE:
+//	Returning error will panic this process. We would rather want this
+// controller to run continuously. Hence, the errors are handled.
+func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) error {
+	s := &syncer{
+		request:  request,
+		response: response,
+	}
+	return s.sync()
+}
+
+// Reconciler enables reconciliation of CStorClusterConfig instance
+type Reconciler struct {
+	ObservedCStorClusterConfig *unstructured.Unstructured
+	ObservedBlockDevices       []*unstructured.Unstructured
+	ObservedCStorPoolCluster   *unstructured.Unstructured
+
+	cccHelper *ccc.Helper
+
+	selectedBlockDevices               []*unstructured.Unstructured
+	hostNameToSelectedBlockDeviceNames map[string][]string
+	hostNameToObservedCSPCDeviceNames  map[string][]string
+	observedHostNamesInCSPC            []string
+
+	deviceSelector             metac.ResourceSelector
+	desiredCStorPoolCluster    *unstructured.Unstructured
+	isDeviceCountMatchRAIDType bool
+	skipReconcile              bool
+	skipReconcileReason        string
+	raidType                   types.PoolRAIDType
+	err                        error
+}
+
+// ReconcileResponse is a helper struct used to form the response
+// of a successful reconciliation
+type ReconcileResponse struct {
+	CStorPoolCluster *unstructured.Unstructured
+	SkipReconcile    bool
+	SkipReason       string
+}
+
+// NilReconcileResponse is used to represent a nil
+// ReconcileResponse value
+var NilReconcileResponse = ReconcileResponse{}
+
+func (r *Reconciler) init() {
+	r.cccHelper = ccc.NewHelper(r.ObservedCStorClusterConfig)
+}
+
+func (r *Reconciler) setRAIDType() {
+	// RAID type is used from CStorClusterConfig specs
+	r.raidType, r.err = r.cccHelper.GetRAIDTypeOrCached()
+}
+
+// selectFromObservedBlockDevices filters the
+// observed blockdevices based on local disk selector terms
+func (r *Reconciler) selectFromObservedBlockDevices() {
+	r.deviceSelector, r.err = r.cccHelper.GetLocalBlockDeviceSelector()
+	if r.err != nil {
+		return
+	}
+	l := unstruct.ListSelector(r.deviceSelector, r.ObservedBlockDevices...)
+	r.selectedBlockDevices, _ = l.List()
+	if len(r.selectedBlockDevices) == 0 {
+		r.err = errors.Errorf(
+			"0 of %d block devices selected", len(r.ObservedBlockDevices),
+		)
+	}
+}
+
+// mapHostNameToSelectedBlockDevices traverses through all the block devices
+// and sets a mapping of hostname to corresponding block device names
+func (r *Reconciler) mapHostNameToSelectedBlockDevices() {
+	l := bd.NewListHelper(r.selectedBlockDevices)
+	r.hostNameToSelectedBlockDeviceNames, r.err = l.GroupDeviceNamesByHostName()
+}
+
+func (r *Reconciler) isSelectedBlockDeviceCountMatchRAIDType() {
+	// match device count on a per node basis
+	for observedNode, selectedBlockDevices := range r.hostNameToSelectedBlockDeviceNames {
+		// does device count match the RAID type
+		r.isDeviceCountMatchRAIDType, r.err =
+			r.cccHelper.IsDiskCountMatchRAIDType(int64(len(selectedBlockDevices)))
+		if r.err != nil {
+			// this was a runtime error
+			return
+		}
+		if !r.isDeviceCountMatchRAIDType {
+			r.err =
+				errors.Errorf(
+					"Can't reconcile: Invalid block device count %d: RAID %q: Node %q",
+					len(selectedBlockDevices), r.raidType, observedNode,
+				)
+			// unsupported device count on any node makes the entire
+			// operation invalid
+			return
+		}
+	}
+}
+
+// walkObservedCStorPoolCluster traverses the observed CStorPoolCluster
+// and set a mapping of hostname to corresponding block device names
+func (r *Reconciler) walkObservedCStorPoolCluster() {
+	// CStorPoolCluster can be nil if it was never created
+	if r.ObservedCStorPoolCluster == nil {
+		// Nothing needs to be done if CSPC is nil
+		return
+	}
+	h := cspc.NewHelper(r.ObservedCStorPoolCluster)
+	// set host names in the **order** they are found at CSPC specs
+	r.observedHostNamesInCSPC, r.err = h.GetOrderedHostNamesOrCached()
+	if r.err != nil {
+		return
+	}
+	// set host name to device names mapping based on what is
+	// observed in CSPC specs
+	r.hostNameToObservedCSPCDeviceNames, r.err = h.GroupBlockDeviceNamesByHostName()
+}
+
+// buildDesiredCStorPoolCluster returns the desired CStorPoolCluster state
+//
+// NOTE:
+//	This logic is idempotent. In other words, it returns same structure
+// for every reconcile action i.e. add, update, even no change in state.
+func (r *Reconciler) buildDesiredCStorPoolCluster() {
+	b := &cspc.Builder{
+		Name:                          r.ObservedCStorClusterConfig.GetName(),
+		Namespace:                     r.ObservedCStorClusterConfig.GetNamespace(),
+		OrderedHostNames:              r.observedHostNamesInCSPC,
+		HostNameToObservedDeviceNames: r.hostNameToObservedCSPCDeviceNames,
+		HostNameToDesiredDeviceNames:  r.hostNameToSelectedBlockDeviceNames,
+		DesiredAnnotations: map[string]string{
+			types.AnnKeyCStorClusterConfigUID: string(r.ObservedCStorClusterConfig.GetUID()),
+		},
+		DesiredRAIDType: r.raidType,
+	}
+	r.desiredCStorPoolCluster, r.err = b.BuildDesiredState()
+}
+
+// Reconcile runs through the reconciliation logic
+//
+// NOTE:
+//	This logic be idempotent. In other words, it behaves the same
+// for every reconcile action i.e. add, update, even no change in
+// state.
+func (r *Reconciler) Reconcile() (ReconcileResponse, error) {
+	if r.ObservedCStorClusterConfig == nil {
+		return NilReconcileResponse,
+			errors.Errorf("Can't reconcile: Nil CStorClusterConfig")
+	}
+	if len(r.ObservedBlockDevices) == 0 {
+		return NilReconcileResponse,
+			errors.Errorf("Can't reconcile: Missing block devices")
+	}
+	r.init()
+	fns := []func(){
+		r.setRAIDType,
+		r.selectFromObservedBlockDevices,
+		r.mapHostNameToSelectedBlockDevices,
+		r.isSelectedBlockDeviceCountMatchRAIDType,
+		r.walkObservedCStorPoolCluster,
+		r.buildDesiredCStorPoolCluster,
+	}
+	for _, fn := range fns {
+		fn()
+		// post operation checks
+		if r.err != nil {
+			return NilReconcileResponse, r.err
+		}
+		if r.skipReconcile {
+			return ReconcileResponse{
+				SkipReconcile: true,
+				SkipReason:    r.skipReconcileReason,
+			}, nil
+		}
+	}
+	return ReconcileResponse{
+		CStorPoolCluster: r.desiredCStorPoolCluster,
+	}, nil
+}

--- a/controller/localdevice/reconciler_test.go
+++ b/controller/localdevice/reconciler_test.go
@@ -1,0 +1,2336 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localdevice
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+	"mayadata.io/cstorpoolauto/unstruct"
+	"openebs.io/metac/controller/common"
+	"openebs.io/metac/controller/generic"
+)
+
+func TestSyncerValidateArgs(t *testing.T) {
+	var tests = map[string]struct {
+		syncer *syncer
+		isErr  bool
+	}{
+		"nil request && nil response": {
+			syncer: &syncer{
+				request:  nil,
+				response: nil,
+			},
+			isErr: true,
+		},
+		"nil request && not nil response": {
+			syncer: &syncer{
+				request:  nil,
+				response: &generic.SyncHookResponse{},
+			},
+			isErr: true,
+		},
+		"nil watch && not nil response": {
+			syncer: &syncer{
+				request:  &generic.SyncHookRequest{},
+				response: &generic.SyncHookResponse{},
+			},
+			isErr: true,
+		},
+		"nil watch object && not nil response": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isErr: true,
+		},
+		"not nil request && not nil response": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			mock.syncer.validateArgs()
+			if mock.isErr && mock.syncer.fatal == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && mock.syncer.fatal != nil {
+				t.Fatalf("Expected no error got [%+v]", mock.syncer.fatal)
+			}
+		})
+	}
+}
+
+func TestSyncerSkipIfNotLocalDisk(t *testing.T) {
+	var tests = map[string]struct {
+		syncer *syncer
+		isSkip bool
+		isErr  bool
+	}{
+		"empty watch": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isErr: true,
+		},
+		"invalid watch kind": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": "Junk",
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isErr: true,
+		},
+		"valid watch kind && empty specs": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && empty diskconfig": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && nil diskconfig.local": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": nil,
+								},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && nil diskconfig.local.blockDeviceSelector": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": nil,
+									},
+								},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && nil diskconfig.local.blockDeviceSelector.selectorTerms": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": map[string]interface{}{
+											"selectorTerms": []interface{}(nil),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && 0 diskconfig.local.blockDeviceSelector.selectorTerms": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": map[string]interface{}{
+											"selectorTerms": []interface{}{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && 1 empty diskconfig.local.blockDeviceSelector.selectorTerms": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": map[string]interface{}{
+											"selectorTerms": []interface{}{
+												map[string]interface{}{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: false,
+			isErr:  false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			mock.syncer.skipIfNotLocalDisk()
+			if mock.isErr && mock.syncer.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && mock.syncer.err != nil {
+				t.Fatalf("Expected no error got [%+v]", mock.syncer.err)
+			}
+			if mock.isSkip != mock.syncer.response.SkipReconcile {
+				t.Fatalf(
+					"Expected skip %t got %t",
+					mock.isSkip, mock.syncer.response.SkipReconcile,
+				)
+			}
+		})
+	}
+}
+
+func TestSyncerSkipIfEmptyAttachments(t *testing.T) {
+	// it is ok to share this watch across all the tests
+	// since this is not manipulated in the test
+	var watch = &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": string(types.KindCStorClusterConfig),
+		},
+	}
+	var tests = map[string]struct {
+		syncer *syncer
+		isSkip bool
+		isErr  bool
+	}{
+		"nil attachments": {
+			syncer: &syncer{
+				request:  &generic.SyncHookRequest{},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+		},
+		"empty attachments": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Attachments: common.AnyUnstructRegistry{},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+		},
+		"empty map as attachments": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Attachments: common.AnyUnstructRegistry(
+						map[string]map[string]*unstructured.Unstructured{},
+					),
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+		},
+		"nil objs as attachments": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Attachments: common.AnyUnstructRegistry(
+						map[string]map[string]*unstructured.Unstructured{
+							"gvk1": map[string]*unstructured.Unstructured{},
+							"gvk2": map[string]*unstructured.Unstructured{
+								"nsname1": nil,
+							},
+						},
+					),
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+		},
+		"1 non nil obj as attachments": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Attachments: common.AnyUnstructRegistry(
+						map[string]map[string]*unstructured.Unstructured{
+							"gvk1": map[string]*unstructured.Unstructured{},
+							"gvk2": map[string]*unstructured.Unstructured{
+								"nsname1": nil,
+							},
+							"gvk3": map[string]*unstructured.Unstructured{
+								"nsname1": &unstructured.Unstructured{},
+							},
+						},
+					),
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			// set the common watch to avoid panic during logging
+			mock.syncer.request.Watch = watch
+			// function under test
+			mock.syncer.skipIfEmptyAttachments()
+			if mock.isErr && mock.syncer.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && mock.syncer.err != nil {
+				t.Fatalf("Expected no error got [%+v]", mock.syncer.err)
+			}
+			if mock.isSkip != mock.syncer.response.SkipReconcile {
+				t.Fatalf(
+					"Expected skip %t got %t",
+					mock.isSkip, mock.syncer.response.SkipReconcile,
+				)
+			}
+		})
+	}
+}
+
+func TestSyncerRegisterAttachments(t *testing.T) {
+	var tests = map[string]struct {
+		syncer                 *syncer
+		expectBlockDeviceCount int
+		expectCStorPoolCluster bool
+		expectAttachmentsCount int
+		isErr                  bool
+	}{
+		"0 attachments": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Attachments: common.AnyUnstructRegistry{},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+		},
+		"1 blockdevice attachment": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Attachments: common.AnyUnstructRegistry(
+						map[string]map[string]*unstructured.Unstructured{
+							"gvk1": map[string]*unstructured.Unstructured{
+								"nsname1": &unstructured.Unstructured{
+									Object: map[string]interface{}{
+										"kind": string(types.KindBlockDevice),
+									},
+								},
+							},
+						},
+					),
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			expectBlockDeviceCount: 1,
+			expectAttachmentsCount: 1,
+		},
+		"2 blockdevice attachments": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Attachments: common.AnyUnstructRegistry(
+						map[string]map[string]*unstructured.Unstructured{
+							"gvk1": map[string]*unstructured.Unstructured{
+								"nsname1": &unstructured.Unstructured{
+									Object: map[string]interface{}{
+										"kind": string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "name1",
+											"namespace": "ns",
+										},
+									},
+								},
+								"nsname2": &unstructured.Unstructured{
+									Object: map[string]interface{}{
+										"kind": string(types.KindBlockDevice),
+										"metadata": map[string]interface{}{
+											"name":      "name2",
+											"namespace": "ns",
+										},
+									},
+								},
+							},
+						},
+					),
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			expectBlockDeviceCount: 2,
+			expectAttachmentsCount: 2,
+		},
+		"2 blockdevice & 1 related CSPC attachments": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"uid": "123",
+							},
+						},
+					},
+					Attachments: common.AnyUnstructRegistry(
+						map[string]map[string]*unstructured.Unstructured{
+							"gvk1": map[string]*unstructured.Unstructured{
+								"nsname1": &unstructured.Unstructured{
+									Object: map[string]interface{}{
+										"kind": string(types.KindBlockDevice),
+									},
+								},
+								"nsname2": &unstructured.Unstructured{
+									Object: map[string]interface{}{
+										"kind": string(types.KindBlockDevice),
+									},
+								},
+							},
+							"gvk2": map[string]*unstructured.Unstructured{
+								"nsname1": &unstructured.Unstructured{
+									Object: map[string]interface{}{
+										"kind": string(types.KindCStorPoolCluster),
+										"metadata": map[string]interface{}{
+											"annotations": map[string]interface{}{
+												types.AnnKeyCStorClusterConfigUID: "123",
+											},
+										},
+									},
+								},
+							},
+						},
+					),
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			expectCStorPoolCluster: true,
+			expectBlockDeviceCount: 2,
+			expectAttachmentsCount: 2,
+		},
+		"2 blockdevice & 1 un-related CSPC attachments": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"uid": "1234",
+							},
+						},
+					},
+					Attachments: common.AnyUnstructRegistry(
+						map[string]map[string]*unstructured.Unstructured{
+							"gvk1": map[string]*unstructured.Unstructured{
+								"nsname1": &unstructured.Unstructured{
+									Object: map[string]interface{}{
+										"kind": string(types.KindBlockDevice),
+									},
+								},
+								"nsname2": &unstructured.Unstructured{
+									Object: map[string]interface{}{
+										"kind": string(types.KindBlockDevice),
+									},
+								},
+							},
+							"gvk2": map[string]*unstructured.Unstructured{
+								"nsname1": &unstructured.Unstructured{
+									Object: map[string]interface{}{
+										"kind": string(types.KindCStorPoolCluster),
+										"metadata": map[string]interface{}{
+											"annotations": map[string]interface{}{
+												types.AnnKeyCStorClusterConfigUID: "123",
+											},
+										},
+									},
+								},
+							},
+						},
+					),
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			expectBlockDeviceCount: 2,
+			expectAttachmentsCount: 3,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			mock.syncer.registerAttachments()
+			if mock.isErr && mock.syncer.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && mock.syncer.err != nil {
+				t.Fatalf("Expected no error got [%+v]", mock.syncer.err)
+			}
+			if mock.expectBlockDeviceCount != len(mock.syncer.blockDevices) {
+				t.Fatalf("Expect block device count %d got %d",
+					mock.expectBlockDeviceCount, len(mock.syncer.blockDevices),
+				)
+			}
+			if mock.expectCStorPoolCluster && mock.syncer.cstorPoolCluster == nil {
+				t.Fatalf("Expect cspc got none")
+			}
+			if !mock.expectCStorPoolCluster && mock.syncer.cstorPoolCluster != nil {
+				t.Fatalf("Expect no cspc got [%+v]", mock.syncer.cstorPoolCluster)
+			}
+			if mock.expectAttachmentsCount != len(mock.syncer.response.Attachments) {
+				t.Fatalf("Expect attachments count %d got %d",
+					mock.expectAttachmentsCount,
+					len(mock.syncer.response.Attachments),
+				)
+			}
+		})
+	}
+}
+
+// TODO
+func TestSyncerReconcile(t *testing.T) {
+	var tests = map[string]struct {
+		syncer                *syncer
+		expectAttachmentCount int
+		isSkipReconcile       bool
+		isErr                 bool
+	}{
+		"empty syncer": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{},
+			},
+			isErr: true,
+		},
+		"non empty watch": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"non empty watch && non empty block devices": {
+			syncer: &syncer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{},
+					},
+				},
+				blockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{},
+				},
+			},
+			isErr: true,
+		},
+		"striped CStorClusterConfig && 1 block device in 1 node && 0 CStorPoolCluster": {
+			syncer: &syncer{
+				response: &generic.SyncHookResponse{},
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test",
+							},
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": map[string]interface{}{},
+									},
+								},
+								"poolConfig": map[string]interface{}{
+									"raidType": string(types.PoolRAIDTypeStripe),
+								},
+							},
+						},
+					},
+				},
+				blockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd1",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectAttachmentCount: 1,
+			isSkipReconcile:       false,
+			isErr:                 false,
+		},
+		"mirror CStorClusterConfig && 1 block device in 1 node && 0 CStorPoolCluster": {
+			syncer: &syncer{
+				response: &generic.SyncHookResponse{},
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test",
+							},
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": map[string]interface{}{},
+									},
+								},
+								"poolConfig": map[string]interface{}{
+									"raidType": string(types.PoolRAIDTypeMirror),
+								},
+							},
+						},
+					},
+				},
+				blockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd1",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"mirror CStorClusterConfig && 2 block devices in 1 node && 0 CStorPoolCluster": {
+			syncer: &syncer{
+				response: &generic.SyncHookResponse{},
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test",
+							},
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": map[string]interface{}{},
+									},
+								},
+								"poolConfig": map[string]interface{}{
+									"raidType": string(types.PoolRAIDTypeMirror),
+								},
+							},
+						},
+					},
+				},
+				blockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd1",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd2",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectAttachmentCount: 1,
+			isSkipReconcile:       false,
+			isErr:                 false,
+		},
+		"mirror CStorClusterConfig && 2 block devices each in 2 nodes && 0 CStorPoolCluster": {
+			syncer: &syncer{
+				response: &generic.SyncHookResponse{},
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test",
+							},
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": map[string]interface{}{},
+									},
+								},
+								"poolConfig": map[string]interface{}{
+									"raidType": string(types.PoolRAIDTypeMirror),
+								},
+							},
+						},
+					},
+				},
+				blockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd11",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd12",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd21",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd22",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectAttachmentCount: 1,
+			isSkipReconcile:       false,
+			isErr:                 false,
+		},
+		"raidz CStorClusterConfig && 3 block devices each in 2 nodes && 0 CStorPoolCluster": {
+			syncer: &syncer{
+				response: &generic.SyncHookResponse{},
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test",
+							},
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": map[string]interface{}{},
+									},
+								},
+								"poolConfig": map[string]interface{}{
+									"raidType": string(types.PoolRAIDTypeRAIDZ),
+								},
+							},
+						},
+					},
+				},
+				blockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd11",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd12",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd13",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd21",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd22",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd23",
+								"namespace": "storage",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectAttachmentCount: 1,
+			isSkipReconcile:       false,
+			isErr:                 false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			s := mock.syncer
+			s.reconcile()
+			if mock.isErr && s.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && s.err != nil {
+				t.Fatalf("Expected no error got [%+v]", s.err)
+			}
+			if mock.isErr {
+				return
+			}
+			if mock.isSkipReconcile != s.response.SkipReconcile {
+				t.Fatalf(
+					"Expected skip %t got %t",
+					mock.isSkipReconcile, s.response.SkipReconcile,
+				)
+			}
+			if mock.expectAttachmentCount != len(s.response.Attachments) {
+				t.Fatalf("Expected attachment count %d got %d",
+					mock.expectAttachmentCount, len(s.response.Attachments),
+				)
+			}
+		})
+	}
+}
+
+func TestReconcilerIsObservedBlockDeviceCountMatchRAIDType(t *testing.T) {
+	var tests = map[string]struct {
+		reconciler *Reconciler
+		isErr      bool
+	}{
+		"no block devices": {
+			reconciler: &Reconciler{
+				ObservedCStorClusterConfig:         nil,
+				hostNameToSelectedBlockDeviceNames: map[string][]string{},
+			},
+			isErr: false,
+		},
+		"nil cstor cluster config": {
+			reconciler: &Reconciler{
+				ObservedCStorClusterConfig: nil,
+				hostNameToSelectedBlockDeviceNames: map[string][]string{
+					"node-001": []string{"bd1"},
+				},
+			},
+			isErr: true,
+		},
+		"mirror cstor cluster config && 1 block device": {
+			reconciler: &Reconciler{
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"spec": map[string]interface{}{
+							"poolConfig": map[string]interface{}{
+								"raidType": string(types.PoolRAIDTypeMirror),
+							},
+						},
+					},
+				},
+				hostNameToSelectedBlockDeviceNames: map[string][]string{
+					"node-001": []string{"bd1"},
+				},
+			},
+			isErr: true,
+		},
+		"mirror cstor cluster config && 2 block devices": {
+			reconciler: &Reconciler{
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"spec": map[string]interface{}{
+							"poolConfig": map[string]interface{}{
+								"raidType": string(types.PoolRAIDTypeMirror),
+							},
+						},
+					},
+				},
+				hostNameToSelectedBlockDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2"},
+				},
+			},
+			isErr: false,
+		},
+		"mirror cstor cluster config && 2, 3 block devices": {
+			reconciler: &Reconciler{
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"spec": map[string]interface{}{
+							"poolConfig": map[string]interface{}{
+								"raidType": string(types.PoolRAIDTypeMirror),
+							},
+						},
+					},
+				},
+				hostNameToSelectedBlockDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2"},
+					"node-002": []string{"bd21", "bd22", "bd23"},
+				},
+			},
+			isErr: true,
+		},
+		"stripe cstor cluster config && 1 block devices": {
+			reconciler: &Reconciler{
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"spec": map[string]interface{}{
+							"poolConfig": map[string]interface{}{
+								"raidType": string(types.PoolRAIDTypeStripe),
+							},
+						},
+					},
+				},
+				hostNameToSelectedBlockDeviceNames: map[string][]string{
+					"node-001": []string{"bd1"},
+				},
+			},
+			isErr: false,
+		},
+		"stripe cstor cluster config && 2, 1 block devices": {
+			reconciler: &Reconciler{
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"spec": map[string]interface{}{
+							"poolConfig": map[string]interface{}{
+								"raidType": string(types.PoolRAIDTypeStripe),
+							},
+						},
+					},
+				},
+				hostNameToSelectedBlockDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2"},
+					"node-002": []string{"bd21"},
+				},
+			},
+			isErr: false,
+		},
+		"raidz cstor cluster config && 3, 3 block devices": {
+			reconciler: &Reconciler{
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"spec": map[string]interface{}{
+							"poolConfig": map[string]interface{}{
+								"raidType": string(types.PoolRAIDTypeRAIDZ),
+							},
+						},
+					},
+				},
+				hostNameToSelectedBlockDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2", "bd3"},
+					"node-002": []string{"bd21", "bd22", "bd23"},
+				},
+			},
+			isErr: false,
+		},
+		"raidz cstor cluster config && 3, 2 block devices": {
+			reconciler: &Reconciler{
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"spec": map[string]interface{}{
+							"poolConfig": map[string]interface{}{
+								"raidType": string(types.PoolRAIDTypeRAIDZ),
+							},
+						},
+					},
+				},
+				hostNameToSelectedBlockDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2", "bd3"},
+					"node-002": []string{"bd21", "bd22"},
+				},
+			},
+			isErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			r := mock.reconciler
+			r.init()
+			r.isSelectedBlockDeviceCountMatchRAIDType()
+			if mock.isErr && r.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && r.err != nil {
+				t.Fatalf("Expected no error got [%+v]", r.err)
+			}
+		})
+	}
+}
+
+func TestReconcilerMapHostNameToSelectedBlockDevices(t *testing.T) {
+	var tests = map[string]struct {
+		reconciler                   *Reconciler
+		expectHostCount              int
+		expectHostToBlockDeviceCount map[string]int
+		isErr                        bool
+	}{
+		"nil observed devices": {
+			reconciler: &Reconciler{
+				selectedBlockDevices: nil,
+			},
+			isErr: false,
+		},
+		"0 observed devices": {
+			reconciler: &Reconciler{
+				selectedBlockDevices: []*unstructured.Unstructured{},
+			},
+			isErr: false,
+		},
+		"1 invalid kind observed device": {
+			reconciler: &Reconciler{
+				selectedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": "Junk",
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"1 valid kind observed device && empty hostname": {
+			reconciler: &Reconciler{
+				selectedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"1 valid kind observed device && valid hostname": {
+			reconciler: &Reconciler{
+				selectedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectHostCount: 1,
+			expectHostToBlockDeviceCount: map[string]int{
+				"node-001": 1,
+			},
+			isErr: false,
+		},
+		"2 valid kind observed devices && valid, invalid hostname": {
+			reconciler: &Reconciler{
+				selectedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "invalid",
+								"namespace": "invalid",
+								"labels":    map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"2 valid kind observed devices && valid single hostname": {
+			reconciler: &Reconciler{
+				selectedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "test2",
+								"namespace": "test",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectHostCount: 1,
+			expectHostToBlockDeviceCount: map[string]int{
+				"node-001": 2,
+			},
+			isErr: false,
+		},
+		"2 valid kind observed devices && valid hostnames": {
+			reconciler: &Reconciler{
+				selectedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "test",
+								"namespace": "test",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "test2",
+								"namespace": "test",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectHostCount: 2,
+			expectHostToBlockDeviceCount: map[string]int{
+				"node-001": 1,
+				"node-002": 1,
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			r := mock.reconciler
+			r.mapHostNameToSelectedBlockDevices()
+			if mock.isErr && r.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && r.err != nil {
+				t.Fatalf("Expected no error got [%+v]", r.err)
+			}
+			if mock.expectHostCount != len(r.hostNameToSelectedBlockDeviceNames) {
+				t.Fatalf("Expected host to BD count %d got %d",
+					mock.expectHostCount, len(r.hostNameToSelectedBlockDeviceNames),
+				)
+			}
+			if mock.isErr {
+				return
+			}
+			for hostname, blockdevices := range r.hostNameToSelectedBlockDeviceNames {
+				if mock.expectHostToBlockDeviceCount[hostname] != len(blockdevices) {
+					t.Fatalf("Expected blockdevice count %d got %d: host %q",
+						mock.expectHostToBlockDeviceCount[hostname],
+						len(blockdevices),
+						hostname,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestReconcilerWalkObservedCStorPoolCluster(t *testing.T) {
+	var tests = map[string]struct {
+		reconciler              *Reconciler
+		expectHostNames         []string
+		expectHostToDeviceNames map[string][]string
+		isErr                   bool
+	}{
+		"nil cstor pool cluster": {
+			reconciler: &Reconciler{
+				ObservedCStorPoolCluster: nil,
+			},
+		},
+		"empty unstruct cstor pool cluster": {
+			reconciler: &Reconciler{
+				ObservedCStorPoolCluster: &unstructured.Unstructured{},
+			},
+			isErr: true,
+		},
+		"invalid kind cstor pool cluster": {
+			reconciler: &Reconciler{
+				ObservedCStorPoolCluster: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Junk",
+					},
+				},
+			},
+			isErr: true,
+		},
+		"valid kind cstor pool cluster && no pools": {
+			reconciler: &Reconciler{
+				ObservedCStorPoolCluster: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorPoolCluster),
+					},
+				},
+			},
+			isErr: true,
+		},
+		"valid kind cstor pool cluster && nil pools": {
+			reconciler: &Reconciler{
+				ObservedCStorPoolCluster: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorPoolCluster),
+						"spec": map[string]interface{}{},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"valid kind cstor pool cluster && empty pools": {
+			reconciler: &Reconciler{
+				ObservedCStorPoolCluster: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorPoolCluster),
+						"spec": map[string]interface{}{
+							"pools": []interface{}{},
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"valid kind cstor pool cluster && 1 pool": {
+			reconciler: &Reconciler{
+				ObservedCStorPoolCluster: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorPoolCluster),
+						"spec": map[string]interface{}{
+							"pools": []interface{}{
+								map[string]interface{}{
+									"poolConfig": map[string]interface{}{
+										"defaultRaidGroupType": "stripe",
+										"overProvisioning":     false,
+										"compression":          "off",
+									},
+									"nodeSelector": map[string]interface{}{
+										"kubernetes.io/hostname": "node-201",
+									},
+									"raidGroups": []interface{}{
+										map[string]interface{}{
+											"blockDevices": []interface{}{
+												map[string]interface{}{
+													"blockDeviceName": "bd-7",
+												},
+											},
+											"type":         "stripe",
+											"isWriteCache": false,
+											"isSpare":      false,
+											"isReadCache":  false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectHostNames: []string{"node-201"},
+			expectHostToDeviceNames: map[string][]string{
+				"node-201": []string{"bd-7"},
+			},
+			isErr: false,
+		},
+		"valid kind cstor pool cluster && 2 pools": {
+			reconciler: &Reconciler{
+				ObservedCStorPoolCluster: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorPoolCluster),
+						"spec": map[string]interface{}{
+							"pools": []interface{}{
+								map[string]interface{}{
+									"poolConfig": map[string]interface{}{
+										"defaultRaidGroupType": "stripe",
+										"overProvisioning":     false,
+										"compression":          "off",
+									},
+									"nodeSelector": map[string]interface{}{
+										"kubernetes.io/hostname": "node-101",
+									},
+									"raidGroups": []interface{}{
+										map[string]interface{}{
+											"blockDevices": []interface{}{
+												map[string]interface{}{
+													"blockDeviceName": "bd-8",
+												},
+											},
+											"type":         "stripe",
+											"isWriteCache": false,
+											"isSpare":      false,
+											"isReadCache":  false,
+										},
+									},
+								},
+								map[string]interface{}{
+									"poolConfig": map[string]interface{}{
+										"defaultRaidGroupType": "stripe",
+										"overProvisioning":     false,
+										"compression":          "off",
+									},
+									"nodeSelector": map[string]interface{}{
+										"kubernetes.io/hostname": "node-201",
+									},
+									"raidGroups": []interface{}{
+										map[string]interface{}{
+											"blockDevices": []interface{}{
+												map[string]interface{}{
+													"blockDeviceName": "bd-7",
+												},
+												map[string]interface{}{
+													"blockDeviceName": "bd-77",
+												},
+											},
+											"type":         "stripe",
+											"isWriteCache": false,
+											"isSpare":      false,
+											"isReadCache":  false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectHostNames: []string{"node-101", "node-201"},
+			expectHostToDeviceNames: map[string][]string{
+				"node-101": []string{"bd-8"},
+				"node-201": []string{"bd-7", "bd-77"},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			r := mock.reconciler
+			r.walkObservedCStorPoolCluster()
+			if mock.isErr && r.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && r.err != nil {
+				t.Fatalf("Expected no error got [%+v]", r.err)
+			}
+			if mock.isErr {
+				return
+			}
+			if !reflect.DeepEqual(mock.expectHostNames, r.observedHostNamesInCSPC) {
+				t.Fatalf(
+					"Expected no diff got %s",
+					cmp.Diff(mock.expectHostNames, r.observedHostNamesInCSPC),
+				)
+			}
+			if r.hostNameToObservedCSPCDeviceNames == nil {
+				r.hostNameToObservedCSPCDeviceNames = map[string][]string{}
+			}
+			for host, expectdevices := range mock.expectHostToDeviceNames {
+				actualdevices := r.hostNameToObservedCSPCDeviceNames[host]
+				if !reflect.DeepEqual(expectdevices, actualdevices) {
+					t.Fatalf("Expected no diff for host %q got %s",
+						host, cmp.Diff(expectdevices, actualdevices),
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestReconcilerBuildDesiredCStorPoolCluster(t *testing.T) {
+	var tests = map[string]struct {
+		reconciler *Reconciler
+		expectCSPC *unstructured.Unstructured
+		isErr      bool
+	}{
+		"mirror cspc": {
+			reconciler: &Reconciler{
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+							"uid":       "ccc-101",
+						},
+					},
+				},
+				observedHostNamesInCSPC: []string{"node-001", "node-002"},
+				hostNameToObservedCSPCDeviceNames: map[string][]string{
+					"node-001": []string{"bd10"},
+					"node-002": []string{"bd20"},
+				},
+				hostNameToSelectedBlockDeviceNames: map[string][]string{
+					"node-001": []string{"bd10", "bd11"},
+					"node-002": []string{"bd20", "bd21"},
+				},
+				raidType: types.PoolRAIDTypeMirror,
+			},
+			expectCSPC: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": types.APIVersionOpenEBSV1Alpha1,
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+						"annotations": map[string]interface{}{
+							string(types.AnnKeyCStorClusterConfigUID): "ccc-101",
+						},
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd10",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd11",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd20",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd21",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"stripe cspc": {
+			reconciler: &Reconciler{
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+							"uid":       "ccc-101",
+						},
+					},
+				},
+				observedHostNamesInCSPC: []string{"node-001", "node-002"},
+				hostNameToObservedCSPCDeviceNames: map[string][]string{
+					"node-001": []string{"bd10"},
+					"node-002": []string{"bd20"},
+				},
+				hostNameToSelectedBlockDeviceNames: map[string][]string{
+					"node-001": []string{"bd10", "bd11"},
+					"node-002": []string{"bd20", "bd21"},
+				},
+				raidType: types.PoolRAIDTypeStripe,
+			},
+			expectCSPC: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": types.APIVersionOpenEBSV1Alpha1,
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+						"annotations": map[string]interface{}{
+							string(types.AnnKeyCStorClusterConfigUID): "ccc-101",
+						},
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "stripe",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd10",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd11",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "stripe",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd20",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd21",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			r := mock.reconciler
+			r.buildDesiredCStorPoolCluster()
+			if mock.isErr && r.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && r.err != nil {
+				t.Fatalf("Expected no error got [%+v]", r.err)
+			}
+			if mock.isErr {
+				return
+			}
+			if !reflect.DeepEqual(mock.expectCSPC, r.desiredCStorPoolCluster) {
+				t.Fatalf(
+					"Expected no diff got\n%s",
+					cmp.Diff(mock.expectCSPC, r.desiredCStorPoolCluster),
+				)
+			}
+		})
+	}
+}
+
+func TestReconcilerReconcile(t *testing.T) {
+	var tests = map[string]struct {
+		reconciler *Reconciler
+		expectCSPC *unstructured.Unstructured
+		isErr      bool
+	}{
+		"nil ObservedBlockDevices": {
+			reconciler: &Reconciler{
+				ObservedBlockDevices: nil,
+			},
+			isErr: true,
+		},
+		"nil ObservedCStorClusterConfig": {
+			reconciler: &Reconciler{
+				ObservedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{},
+					},
+				},
+				ObservedCStorClusterConfig: nil,
+			},
+			isErr: true,
+		},
+		"invalid ObservedCStorClusterConfig": {
+			reconciler: &Reconciler{
+				ObservedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{},
+					},
+				},
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Junk",
+					},
+				},
+			},
+			isErr: true,
+		},
+		"expect mirror cspc when observed cspc is nil": {
+			reconciler: &Reconciler{
+				ObservedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name": "bd1",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name": "bd2",
+								"labels": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+							},
+						},
+					},
+				},
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+							"uid":       "ccc-101",
+						},
+						"spec": map[string]interface{}{
+							"poolConfig": map[string]interface{}{
+								"raidType": "mirror",
+							},
+							"diskConfig": map[string]interface{}{
+								"local": map[string]interface{}{
+									"blockDeviceSelector": map[string]interface{}{
+										"selectorTerms": []interface{}(nil),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectCSPC: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": types.APIVersionOpenEBSV1Alpha1,
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+						"annotations": map[string]interface{}{
+							string(types.AnnKeyCStorClusterConfigUID): "ccc-101",
+						},
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd1",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd2",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			r := mock.reconciler
+			resp, err := r.Reconcile()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if mock.isErr {
+				return
+			}
+			if !reflect.DeepEqual(mock.expectCSPC, resp.CStorPoolCluster) {
+				t.Fatalf("Expected no diff got\n%s",
+					cmp.Diff(mock.expectCSPC, resp.CStorPoolCluster),
+				)
+			}
+		})
+	}
+}
+
+func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
+	var tests = map[string]struct {
+		reconciler         *Reconciler
+		expectBlockDevices []*unstructured.Unstructured
+		isErr              bool
+	}{
+		"nil observed block devices": {
+			reconciler: &Reconciler{},
+			isErr:      true,
+		},
+		"empty observed block devices": {
+			reconciler: &Reconciler{
+				ObservedBlockDevices: []*unstructured.Unstructured{},
+			},
+			isErr: true,
+		},
+		"no blockdevice selector": {
+			reconciler: &Reconciler{
+				ObservedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd1",
+								"namespace": "openebs",
+							},
+							"spec": map[string]interface{}{
+								"path": "/dev/sdc",
+							},
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"empty blockdevice selector terms": {
+			reconciler: &Reconciler{
+				ObservedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd1",
+								"namespace": "openebs",
+							},
+							"spec": map[string]interface{}{
+								"path": "/dev/sdc",
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd2",
+								"namespace": "openebs",
+							},
+							"spec": map[string]interface{}{
+								"path": "/dev/sdb",
+							},
+						},
+					},
+				},
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+						"spec": map[string]interface{}{
+							"diskConfig": map[string]interface{}{
+								"local": map[string]interface{}{
+									"blockDeviceSelector": map[string]interface{}{
+										"selectorTerms": []interface{}(nil),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectBlockDevices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindBlockDevice),
+						"metadata": map[string]interface{}{
+							"name":      "bd1",
+							"namespace": "openebs",
+						},
+						"spec": map[string]interface{}{
+							"path": "/dev/sdc",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindBlockDevice),
+						"metadata": map[string]interface{}{
+							"name":      "bd2",
+							"namespace": "openebs",
+						},
+						"spec": map[string]interface{}{
+							"path": "/dev/sdb",
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"passing path based blockdevice selector term": {
+			reconciler: &Reconciler{
+				ObservedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd1",
+								"namespace": "openebs",
+							},
+							"spec": map[string]interface{}{
+								"path": "/dev/sdc",
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd2",
+								"namespace": "openebs",
+							},
+							"spec": map[string]interface{}{
+								"path": "/dev/sdb",
+							},
+						},
+					},
+				},
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+						"spec": map[string]interface{}{
+							"diskConfig": map[string]interface{}{
+								"local": map[string]interface{}{
+									"blockDeviceSelector": map[string]interface{}{
+										"selectorTerms": []interface{}{
+											map[string]interface{}{
+												"matchFields": map[string]interface{}{
+													"spec.path": "/dev/sdb",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectBlockDevices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindBlockDevice),
+						"metadata": map[string]interface{}{
+							"name":      "bd2",
+							"namespace": "openebs",
+						},
+						"spec": map[string]interface{}{
+							"path": "/dev/sdb",
+						},
+					},
+				},
+			},
+			isErr: true, // bug in metac path based field selector
+		},
+		"failing path based blockdevice selector term": {
+			reconciler: &Reconciler{
+				ObservedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd1",
+								"namespace": "openebs",
+							},
+							"spec": map[string]interface{}{
+								"path": "/dev/sdc",
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd2",
+								"namespace": "openebs",
+							},
+							"spec": map[string]interface{}{
+								"path": "/dev/sdb",
+							},
+						},
+					},
+				},
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+						"spec": map[string]interface{}{
+							"diskConfig": map[string]interface{}{
+								"local": map[string]interface{}{
+									"blockDeviceSelector": map[string]interface{}{
+										"selectorTerms": []interface{}{
+											map[string]interface{}{
+												"matchFields": map[string]interface{}{
+													"spec.path": "/dev/sdd",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		"passing label based blockdevice selector term": {
+			reconciler: &Reconciler{
+				ObservedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd1",
+								"namespace": "openebs",
+								"labels": map[string]interface{}{
+									"app": "ndm-1",
+								},
+							},
+							"spec": map[string]interface{}{
+								"path": "/dev/sdc",
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd2",
+								"namespace": "openebs",
+								"labels": map[string]interface{}{
+									"app": "ndm-2",
+								},
+							},
+							"spec": map[string]interface{}{
+								"path": "/dev/sdb",
+							},
+						},
+					},
+				},
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+						"spec": map[string]interface{}{
+							"diskConfig": map[string]interface{}{
+								"local": map[string]interface{}{
+									"blockDeviceSelector": map[string]interface{}{
+										"selectorTerms": []interface{}{
+											map[string]interface{}{
+												"matchFields": map[string]interface{}{
+													"metadata.labels.app": "ndm-1",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectBlockDevices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindBlockDevice),
+						"metadata": map[string]interface{}{
+							"name":      "bd1",
+							"namespace": "openebs",
+							"labels": map[string]interface{}{
+								"app": "ndm-1",
+							},
+						},
+						"spec": map[string]interface{}{
+							"path": "/dev/sdc",
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"failing label based blockdevice selector term": {
+			reconciler: &Reconciler{
+				ObservedBlockDevices: []*unstructured.Unstructured{
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd1",
+								"namespace": "openebs",
+								"labels": map[string]interface{}{
+									"app": "ndm-1",
+								},
+							},
+							"spec": map[string]interface{}{
+								"path": "/dev/sdc",
+							},
+						},
+					},
+					&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindBlockDevice),
+							"metadata": map[string]interface{}{
+								"name":      "bd2",
+								"namespace": "openebs",
+								"labels": map[string]interface{}{
+									"app": "ndm-2",
+								},
+							},
+							"spec": map[string]interface{}{
+								"path": "/dev/sdb",
+							},
+						},
+					},
+				},
+				ObservedCStorClusterConfig: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+						"spec": map[string]interface{}{
+							"diskConfig": map[string]interface{}{
+								"local": map[string]interface{}{
+									"blockDeviceSelector": map[string]interface{}{
+										"selectorTerms": []interface{}{
+											map[string]interface{}{
+												"matchFields": map[string]interface{}{
+													"metadata.labels.app": "ndm-33",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			r := mock.reconciler
+			r.init()
+			r.selectFromObservedBlockDevices()
+			if mock.isErr && r.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && r.err != nil {
+				t.Fatalf("Expected no error got [%+v]", r.err)
+			}
+			if mock.isErr {
+				return
+			}
+			if len(r.selectedBlockDevices) != len(mock.expectBlockDevices) {
+				t.Fatalf("Expected block device count %d got %d",
+					len(mock.expectBlockDevices), len(r.selectedBlockDevices),
+				)
+			}
+			l := unstruct.List(r.selectedBlockDevices)
+			if !l.ContainsAll(mock.expectBlockDevices) {
+				t.Fatalf("Expected no diff got \n%s",
+					cmp.Diff(r.selectedBlockDevices, mock.expectBlockDevices),
+				)
+			}
+		})
+	}
+}

--- a/types/cstorclusterconfig.go
+++ b/types/cstorclusterconfig.go
@@ -65,8 +65,8 @@ type CStorClusterConfigSpec struct {
 type DiskConfig struct {
 	MinCount           resource.Quantity   `json:"minCount"`
 	MinCapacity        resource.Quantity   `json:"minCapacity"`
-	ExternalDiskConfig *ExternalDiskConfig `json:"external"`
-	LocalDiskConfig    *LocalDiskConfig    `json:"local"`
+	ExternalDiskConfig *ExternalDiskConfig `json:"external,omitempty"`
+	LocalDiskConfig    *LocalDiskConfig    `json:"local,omitempty"`
 }
 
 // ExternalDiskConfig has the details required to provision
@@ -111,11 +111,11 @@ type ComputeResources struct {
 type PoolRAIDType string
 
 const (
-	// PoolRAIDTypeMirror represents a mirror pool type
-	PoolRAIDTypeMirror PoolRAIDType = "mirror"
-
 	// PoolRAIDTypeStripe represents a stripe pool type
 	PoolRAIDTypeStripe PoolRAIDType = "stripe"
+
+	// PoolRAIDTypeMirror represents a mirror pool type
+	PoolRAIDTypeMirror PoolRAIDType = "mirror"
 
 	// PoolRAIDTypeRAIDZ represents a raidz pool type
 	PoolRAIDTypeRAIDZ PoolRAIDType = "raidz"
@@ -130,8 +130,8 @@ const (
 // RAIDTypeToDefaultMinDiskCount maps pool instance's raid type
 // to its default minimum disk count
 var RAIDTypeToDefaultMinDiskCount = map[PoolRAIDType]int64{
-	PoolRAIDTypeMirror: 2,
 	PoolRAIDTypeStripe: 1,
+	PoolRAIDTypeMirror: 2,
 	PoolRAIDTypeRAIDZ:  3,
 	PoolRAIDTypeRAIDZ2: 6,
 }

--- a/unstruct/iterator_test.go
+++ b/unstruct/iterator_test.go
@@ -99,8 +99,8 @@ func TestUnstructIterator(t *testing.T) {
 	}
 	tests := map[string]struct {
 		obj                *unstructured.Unstructured
-		getNodeName        UnstructOpsFn
-		getBlockDeviceName UnstructOpsFn
+		getNodeName        OperationFn
+		getBlockDeviceName OperationFn
 		isErr              bool
 	}{
 		"no errors": {

--- a/unstruct/list.go
+++ b/unstruct/list.go
@@ -25,13 +25,17 @@ type List []*unstructured.Unstructured
 // Contains returns true if provided name && uid is
 // is available in this List.
 func (s List) Contains(target *unstructured.Unstructured) bool {
-	if target == nil {
+	if target == nil || target.Object == nil {
 		// we don't know how to compare against a nil
 		return false
 	}
 	for _, obj := range s {
+		if obj == nil || obj.Object == nil {
+			continue
+		}
 		if obj.GetName() == target.GetName() &&
 			obj.GetNamespace() == target.GetNamespace() &&
+			obj.GetUID() == target.GetUID() &&
 			obj.GetKind() == target.GetKind() &&
 			obj.GetAPIVersion() == target.GetAPIVersion() {
 			return true

--- a/unstruct/list_test.go
+++ b/unstruct/list_test.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstruct
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestListContains(t *testing.T) {
+	var tests = map[string]struct {
+		list    []*unstructured.Unstructured
+		given   *unstructured.Unstructured
+		isFound bool
+	}{
+		"nil list": {
+			isFound: false,
+		},
+		"nil list & some given": {
+			given: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Some",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+				},
+			},
+			isFound: false,
+		},
+		"empty list & some given": {
+			list: []*unstructured.Unstructured{},
+			given: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Some",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+				},
+			},
+			isFound: false,
+		},
+		"list & given are different": {
+			list: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Something",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			given: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Some",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+				},
+			},
+			isFound: false,
+		},
+		"list contains given": {
+			list: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Something",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Some",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			given: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Some",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+				},
+			},
+			isFound: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			l := List(mock.list)
+			found := l.Contains(mock.given)
+			if mock.isFound != found {
+				t.Fatalf("Expected found %t got %t",
+					mock.isFound, found,
+				)
+			}
+		})
+	}
+}
+
+func TestListContainsAll(t *testing.T) {
+	var tests = map[string]struct {
+		list    []*unstructured.Unstructured
+		given   []*unstructured.Unstructured
+		isFound bool
+	}{
+		"nil list": {
+			isFound: false,
+		},
+		"nil list & some given": {
+			given: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Some",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			isFound: false,
+		},
+		"empty list & some given": {
+			list: []*unstructured.Unstructured{},
+			given: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Some",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			isFound: false,
+		},
+		"list & given are different": {
+			list: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Something",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			given: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Some",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			isFound: false,
+		},
+		"list contains given": {
+			list: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Something",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Some",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			given: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Some",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			isFound: true,
+		},
+		"list contains all the given": {
+			list: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Something",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Some",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			given: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Some",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Something",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			isFound: true,
+		},
+		"list does not contain all the given": {
+			list: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Something",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Some",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			given: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "SomeOne",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Something",
+						"metadata": map[string]interface{}{
+							"name":      "test",
+							"namespace": "test",
+						},
+					},
+				},
+			},
+			isFound: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			l := List(mock.list)
+			found := l.ContainsAll(mock.given)
+			if mock.isFound != found {
+				t.Fatalf("Expected found %t got %t",
+					mock.isFound, found,
+				)
+			}
+		})
+	}
+}

--- a/util/blockdevice/helper.go
+++ b/util/blockdevice/helper.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockdevice
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+	"mayadata.io/cstorpoolauto/unstruct"
+)
+
+// Helper exposes utility methods w.r.t BlockDevice unstructured
+// instance
+type Helper struct {
+	BlockDevice *unstructured.Unstructured
+
+	err error
+}
+
+// NewHelper returns a new instance of Helper
+func NewHelper(device *unstructured.Unstructured) *Helper {
+	var err error
+	if device == nil || device.Object == nil {
+		err = errors.Errorf(
+			"Can't init device helper: Nil object",
+		)
+	} else if device.GetKind() != string(types.KindBlockDevice) {
+		err = errors.Errorf(
+			"Can't init device helper: Invalid kind: Want %q got %q",
+			types.KindBlockDevice, device.GetKind(),
+		)
+	}
+	if err != nil {
+		return &Helper{
+			err: err,
+		}
+	}
+	return &Helper{
+		BlockDevice: device,
+	}
+}
+
+// GetHostName returns the hostname associated with the blockdevice
+func (h *Helper) GetHostName() (string, error) {
+	if h.err != nil {
+		return "", h.err
+	}
+	return unstruct.GetStringOrError(
+		h.BlockDevice, "metadata", "labels", "kubernetes.io/hostname",
+	)
+}

--- a/util/blockdevice/helper_test.go
+++ b/util/blockdevice/helper_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockdevice
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+)
+
+func TestNewHelper(t *testing.T) {
+	var tests = map[string]struct {
+		device *unstructured.Unstructured
+		isErr  bool
+	}{
+		"nil device": {
+			isErr: true,
+		},
+		"nil device object": {
+			device: &unstructured.Unstructured{},
+			isErr:  true,
+		},
+		"invalid device kind": {
+			device: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Junk",
+				},
+			},
+			isErr: true,
+		},
+		"valid device kind": {
+			device: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindBlockDevice),
+				},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewHelper(mock.device)
+			if mock.isErr && h.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && h.err != nil {
+				t.Fatalf("Expected no error got [%+v]", h.err)
+			}
+		})
+	}
+}

--- a/util/blockdevice/list_helper.go
+++ b/util/blockdevice/list_helper.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockdevice
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+)
+
+// ListHelper exposes utility methods for a list of
+// BlockDevice unstructured instances
+type ListHelper struct {
+	BlockDevices []*unstructured.Unstructured
+
+	err error
+}
+
+// NewListHelper returns a new instance of ListHelper
+func NewListHelper(devices []*unstructured.Unstructured) *ListHelper {
+	var err error
+	var errmsgs []string
+	for idx, device := range devices {
+		if device == nil || device.Object == nil {
+			msg := fmt.Sprintf(
+				"Can't init device list helper: Nil device at %d", idx,
+			)
+			errmsgs = append(errmsgs, msg)
+		} else if device.GetKind() != string(types.KindBlockDevice) {
+			msg := fmt.Sprintf(
+				"Can't init device list helper: Invalid kind: Want %q got %q at %d",
+				types.KindBlockDevice, device.GetKind(), idx,
+			)
+			errmsgs = append(errmsgs, msg)
+		}
+	}
+	if len(errmsgs) != 0 {
+		err = errors.Errorf(
+			"%d errors found: [%s]",
+			len(errmsgs), strings.Join(errmsgs, ", "),
+		)
+	}
+	if err != nil {
+		return &ListHelper{err: err}
+	}
+	return &ListHelper{
+		BlockDevices: devices,
+	}
+}
+
+// GroupDeviceNamesByHostName returns a list of devicenames
+// grouped by their hostname
+func (l *ListHelper) GroupDeviceNamesByHostName() (map[string][]string, error) {
+	if l.err != nil {
+		return nil, l.err
+	}
+	hostNameToDeviceNames := map[string][]string{}
+	for _, device := range l.BlockDevices {
+		h := NewHelper(device)
+		host, err := h.GetHostName()
+		if err != nil {
+			return nil, err
+		}
+		hostNameToDeviceNames[host] =
+			append(hostNameToDeviceNames[host], device.GetName())
+	}
+	return hostNameToDeviceNames, nil
+}

--- a/util/blockdevice/list_helper_test.go
+++ b/util/blockdevice/list_helper_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockdevice
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+)
+
+func TestNewListHelper(t *testing.T) {
+	var tests = map[string]struct {
+		devices []*unstructured.Unstructured
+		isErr   bool
+	}{
+		"nil devices": {
+			isErr: false,
+		},
+		"empty devices": {
+			devices: []*unstructured.Unstructured{},
+			isErr:   false,
+		},
+		"1 nil object device": {
+			devices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{},
+			},
+			isErr: true,
+		},
+		"1 invalid kind device": {
+			devices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Junk",
+					},
+				},
+			},
+			isErr: true,
+		},
+		"1 valid kind device": {
+			devices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindBlockDevice),
+					},
+				},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewListHelper(mock.devices)
+			if mock.isErr && h.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && h.err != nil {
+				t.Fatalf("Expected no error got [%+v]", h.err)
+			}
+		})
+	}
+}
+
+func TestListHelperGroupDeviceNameByHostName(t *testing.T) {
+	var tests = map[string]struct {
+		devices                 []*unstructured.Unstructured
+		expectHostToDeviceCount map[string]int
+		isErr                   bool
+	}{
+		"nil devices": {
+			isErr: false,
+		},
+		"empty devices": {
+			devices: []*unstructured.Unstructured{},
+			isErr:   false,
+		},
+		"1 nil device object": {
+			devices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{},
+			},
+			isErr: true,
+		},
+		"1 invalid device kind": {
+			devices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Junk",
+					},
+				},
+			},
+			isErr: true,
+		},
+		"missing specs in device kind": {
+			devices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindBlockDevice),
+					},
+				},
+			},
+			isErr: true,
+		},
+		"with hostname in device": {
+			devices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindBlockDevice),
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"kubernetes.io/hostname": "node-001",
+							},
+						},
+					},
+				},
+			},
+			expectHostToDeviceCount: map[string]int{
+				"node-001": 1,
+			},
+			isErr: false,
+		},
+		"multiple devices with hostname": {
+			devices: []*unstructured.Unstructured{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindBlockDevice),
+						"metadata": map[string]interface{}{
+							"name":      "bd1",
+							"namespace": "openebs",
+							"labels": map[string]interface{}{
+								"kubernetes.io/hostname": "node-001",
+							},
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindBlockDevice),
+						"metadata": map[string]interface{}{
+							"name":      "bd2",
+							"namespace": "openebs",
+							"labels": map[string]interface{}{
+								"kubernetes.io/hostname": "node-002",
+							},
+						},
+					},
+				},
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindBlockDevice),
+						"metadata": map[string]interface{}{
+							"name":      "bd3",
+							"namespace": "openebs",
+							"labels": map[string]interface{}{
+								"kubernetes.io/hostname": "node-002",
+							},
+						},
+					},
+				},
+			},
+			expectHostToDeviceCount: map[string]int{
+				"node-001": 1,
+				"node-002": 2,
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewListHelper(mock.devices)
+			got, err := h.GroupDeviceNamesByHostName()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if mock.isErr {
+				return
+			}
+			if len(got) != len(mock.expectHostToDeviceCount) {
+				t.Fatalf("Expected host to device count %d got %d",
+					len(mock.expectHostToDeviceCount), len(got),
+				)
+			}
+			for host, devices := range got {
+				if mock.expectHostToDeviceCount[host] != len(devices) {
+					t.Fatalf("Expected device count %d got %d: Host %s",
+						mock.expectHostToDeviceCount[host], len(devices), host,
+					)
+				}
+			}
+		})
+	}
+}

--- a/util/cstorclusterconfig/helper.go
+++ b/util/cstorclusterconfig/helper.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorclusterconfig
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+	"mayadata.io/cstorpoolauto/unstruct"
+
+	metac "openebs.io/metac/apis/metacontroller/v1alpha1"
+)
+
+var nilselector = metac.ResourceSelector{}
+
+// Helper provides all utility methods against a CStorClusterConfig
+// unstructured instance
+type Helper struct {
+	ClusterConfig *unstructured.Unstructured
+
+	raidType types.PoolRAIDType
+	err      error
+}
+
+// NewHelper returns a new instance of CStorClusterConfig based helper
+func NewHelper(obj *unstructured.Unstructured) *Helper {
+	var h = &Helper{}
+	if obj == nil || obj.Object == nil {
+		h.err = errors.Errorf("Can't init helper: Nil object")
+		return h
+	}
+	if obj.GetKind() != string(types.KindCStorClusterConfig) {
+		h.err = errors.Errorf(
+			"Can't init helper: Invalid kind: Want %q got %q",
+			string(types.KindCStorClusterConfig), obj.GetKind(),
+		)
+		return h
+	}
+	h.ClusterConfig = obj
+	return h
+}
+
+// IsLocalBlockDiskConfig returns true if provided CStorClusterConfig
+// is set with local block disk configuration
+func (h *Helper) IsLocalBlockDiskConfig() (bool, error) {
+	if h.err != nil {
+		return false, h.err
+	}
+	localDiskSelectTerms, found, err := unstructured.NestedSlice(
+		h.ClusterConfig.Object,
+		"spec",
+		"diskConfig",
+		"local",
+		"blockDeviceSelector",
+		"selectorTerms",
+	)
+	if err != nil {
+		return false, err
+	}
+	if !found || len(localDiskSelectTerms) == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+// GetLocalBlockDeviceSelector returns block disk selector that has been
+// configured to match against any block device(s)
+func (h *Helper) GetLocalBlockDeviceSelector() (metac.ResourceSelector, error) {
+	if h.err != nil {
+		return nilselector, h.err
+	}
+	var cstorClusterConfigTyped = types.CStorClusterConfig{}
+	err := unstruct.UnstructToTyped(h.ClusterConfig, &cstorClusterConfigTyped)
+	if err != nil {
+		return nilselector, err
+	}
+	localDiskConf := cstorClusterConfigTyped.Spec.DiskConfig.LocalDiskConfig
+	if localDiskConf == nil {
+		return nilselector,
+			errors.Errorf("Can't get disk selector: Nil LocalDiskConfig")
+	}
+	return localDiskConf.BlockDeviceSelector, nil
+}
+
+// IsDiskCountMatchRAIDType returns true if given count
+// is supported by the RAIDType that is set against this
+// CStorClusterConfig instance
+func (h *Helper) IsDiskCountMatchRAIDType(count int64) (bool, error) {
+	if h.err != nil {
+		return false, h.err
+	}
+	if count <= 0 {
+		return false, errors.Errorf("Can't match: Invalid disk count %d", count)
+	}
+	raid, err := h.GetRAIDTypeOrCached()
+	if err != nil {
+		return false, err
+	}
+	h.raidType = raid
+	// check if remainder is zero
+	if count%types.RAIDTypeToDefaultMinDiskCount[h.raidType] == 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+// GetRAIDType returns the raid type of this CStorClusterConfig
+// instance
+func (h *Helper) GetRAIDType() (types.PoolRAIDType, error) {
+	if h.err != nil {
+		return "", h.err
+	}
+	raid, err :=
+		unstruct.GetStringOrError(h.ClusterConfig, "spec", "poolConfig", "raidType")
+	if err != nil {
+		return "", err
+	}
+	h.raidType = types.PoolRAIDType(raid)
+	return h.raidType, nil
+}
+
+// GetRAIDTypeOrCached returns the raid type of this CStorClusterConfig
+// instance
+func (h *Helper) GetRAIDTypeOrCached() (types.PoolRAIDType, error) {
+	if h.err != nil {
+		return "", h.err
+	}
+	// check if cached value is available
+	if h.raidType != "" {
+		// return cached value
+		return h.raidType, nil
+	}
+	return h.GetRAIDType()
+}

--- a/util/cstorclusterconfig/helper_test.go
+++ b/util/cstorclusterconfig/helper_test.go
@@ -1,0 +1,1005 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorclusterconfig
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+	metac "openebs.io/metac/apis/metacontroller/v1alpha1"
+)
+
+func TestNewHelper(t *testing.T) {
+	var tests = map[string]struct {
+		cstorClusterConfig *unstructured.Unstructured
+		isErr              bool
+	}{
+		"nil cstor cluster config": {
+			cstorClusterConfig: nil,
+			isErr:              true,
+		},
+		"nil cstor cluster config object": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: nil,
+			},
+			isErr: true,
+		},
+		"invalid cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Junk",
+				},
+			},
+			isErr: true,
+		},
+		"cstor cluster config with valid kind": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+				},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewHelper(mock.cstorClusterConfig)
+			if mock.isErr && h.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && h.err != nil {
+				t.Fatalf("Expected no error got [%+v]", h.err)
+			}
+		})
+	}
+}
+
+func TestHelperIsLocalDisk(t *testing.T) {
+	var tests = map[string]struct {
+		cstorClusterConfig *unstructured.Unstructured
+		isLocal            bool
+		isErr              bool
+	}{
+		"nil cstor cluster config": {
+			cstorClusterConfig: nil,
+			isErr:              true,
+		},
+		"nil cstor cluster config object": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: nil,
+			},
+			isErr: true,
+		},
+		"invalid cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Junk",
+				},
+			},
+			isErr: true,
+		},
+		"cstor cluster config with valid kind": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+				},
+			},
+			isErr: false,
+		},
+		"cstor cluster config && valid kind && remote disk": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"remote": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			isLocal: false,
+			isErr:   false,
+		},
+		"cstor cluster config && valid kind && nil local disk": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"local": nil,
+						},
+					},
+				},
+			},
+			isLocal: false,
+			isErr:   false,
+		},
+		"cstor cluster config && valid kind && valid local disk select terms": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"local": map[string]interface{}{
+								"blockDeviceSelector": map[string]interface{}{
+									"selectorTerms": []interface{}{
+										map[string]interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isLocal: true,
+			isErr:   false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewHelper(mock.cstorClusterConfig)
+			got, err := h.IsLocalBlockDiskConfig()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if got != mock.isLocal {
+				t.Fatalf("Expected local %t got %t", mock.isLocal, got)
+			}
+		})
+	}
+}
+
+func TestHelperIsDiskCountMatchRAIDType(t *testing.T) {
+	var tests = map[string]struct {
+		cstorClusterConfig *unstructured.Unstructured
+		diskCount          int64
+		isMatch            bool
+		isErr              bool
+	}{
+		"2 disks mirror cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeMirror),
+						},
+					},
+				},
+			},
+			diskCount: 2,
+			isMatch:   true,
+			isErr:     false,
+		},
+		"3 disks mirror cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeMirror),
+						},
+					},
+				},
+			},
+			diskCount: 3,
+			isMatch:   false,
+			isErr:     false,
+		},
+		"4 disks mirror cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeMirror),
+						},
+					},
+				},
+			},
+			diskCount: 4,
+			isMatch:   true,
+			isErr:     false,
+		},
+		"3 disks raidz cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ),
+						},
+					},
+				},
+			},
+			diskCount: 3,
+			isMatch:   true,
+			isErr:     false,
+		},
+		"4 disks raidz cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ),
+						},
+					},
+				},
+			},
+			diskCount: 4,
+			isMatch:   false,
+			isErr:     false,
+		},
+		"1 disks raidz cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ),
+						},
+					},
+				},
+			},
+			diskCount: 1,
+			isMatch:   false,
+			isErr:     false,
+		},
+		"6 disks raidz2 cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ2),
+						},
+					},
+				},
+			},
+			diskCount: 6,
+			isMatch:   true,
+			isErr:     false,
+		},
+		"7 disks raidz2 cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ2),
+						},
+					},
+				},
+			},
+			diskCount: 7,
+			isMatch:   false,
+			isErr:     false,
+		},
+		"2 disks stripe cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeStripe),
+						},
+					},
+				},
+			},
+			diskCount: 2,
+			isMatch:   true,
+			isErr:     false,
+		},
+		"1 disks stripe cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeStripe),
+						},
+					},
+				},
+			},
+			diskCount: 1,
+			isMatch:   true,
+			isErr:     false,
+		},
+		"0 disks stripe cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeStripe),
+						},
+					},
+				},
+			},
+			diskCount: 0,
+			isMatch:   false,
+			isErr:     true,
+		},
+		"-1 disks stripe cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeStripe),
+						},
+					},
+				},
+			},
+			diskCount: -1,
+			isMatch:   false,
+			isErr:     true,
+		},
+		"0 disks mirror cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeMirror),
+						},
+					},
+				},
+			},
+			diskCount: 0,
+			isMatch:   false,
+			isErr:     true,
+		},
+		"-1 disks mirror cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeMirror),
+						},
+					},
+				},
+			},
+			diskCount: -1,
+			isMatch:   false,
+			isErr:     true,
+		},
+		"0 disks raidz cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ),
+						},
+					},
+				},
+			},
+			diskCount: 0,
+			isMatch:   false,
+			isErr:     true,
+		},
+		"-1 disks raidz cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ),
+						},
+					},
+				},
+			},
+			diskCount: -1,
+			isMatch:   false,
+			isErr:     true,
+		},
+		"0 disks raidz2 cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ2),
+						},
+					},
+				},
+			},
+			diskCount: 0,
+			isMatch:   false,
+			isErr:     true,
+		},
+		"-1 disks raidz2 cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ2),
+						},
+					},
+				},
+			},
+			diskCount: -1,
+			isMatch:   false,
+			isErr:     true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewHelper(mock.cstorClusterConfig)
+			match, err := h.IsDiskCountMatchRAIDType(mock.diskCount)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Exepcted no error got [%+v]", err)
+			}
+			if mock.isMatch != match {
+				t.Fatalf("Expected match %t got %t", mock.isMatch, match)
+			}
+		})
+	}
+}
+
+func TestHelperGetRAIDType(t *testing.T) {
+	var tests = map[string]struct {
+		cstorClusterConfig *unstructured.Unstructured
+		expectRAIDType     types.PoolRAIDType
+		isErr              bool
+	}{
+		"nil cstor cluster config": {
+			isErr: true,
+		},
+		"empty cstor cluster config object": {
+			cstorClusterConfig: &unstructured.Unstructured{},
+			isErr:              true,
+		},
+		"invalid cstor cluster config kind": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Junk",
+				},
+			},
+			isErr: true,
+		},
+		"missing raid type": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": nil,
+					},
+				},
+			},
+			isErr: true,
+		},
+		"mirror cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeMirror),
+						},
+					},
+				},
+			},
+			expectRAIDType: types.PoolRAIDTypeMirror,
+			isErr:          false,
+		},
+		"stripe cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeStripe),
+						},
+					},
+				},
+			},
+			expectRAIDType: types.PoolRAIDTypeStripe,
+			isErr:          false,
+		},
+		"raidz cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ),
+						},
+					},
+				},
+			},
+			expectRAIDType: types.PoolRAIDTypeRAIDZ,
+			isErr:          false,
+		},
+		"raidz2 cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ2),
+						},
+					},
+				},
+			},
+			expectRAIDType: types.PoolRAIDTypeRAIDZ2,
+			isErr:          false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewHelper(mock.cstorClusterConfig)
+			got, err := h.GetRAIDType()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if mock.isErr {
+				return
+			}
+			if got != mock.expectRAIDType {
+				t.Fatalf("Expected raid type %s got %s", mock.expectRAIDType, got)
+			}
+		})
+	}
+}
+
+func TestHelperGetRAIDTypeOrCached(t *testing.T) {
+	var tests = map[string]struct {
+		cstorClusterConfig *unstructured.Unstructured
+		givenRAIDType      types.PoolRAIDType
+		expectRAIDType     types.PoolRAIDType
+		isErr              bool
+	}{
+		"no cache && raidz2": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ2),
+						},
+					},
+				},
+			},
+			expectRAIDType: types.PoolRAIDTypeRAIDZ2,
+			isErr:          false,
+		},
+		"raidz2 cache": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ2),
+						},
+					},
+				},
+			},
+			givenRAIDType:  types.PoolRAIDTypeRAIDZ2,
+			expectRAIDType: types.PoolRAIDTypeRAIDZ2,
+			isErr:          false,
+		},
+		"no cache && raidz": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ),
+						},
+					},
+				},
+			},
+			expectRAIDType: types.PoolRAIDTypeRAIDZ,
+			isErr:          false,
+		},
+		"raidz cache": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeRAIDZ),
+						},
+					},
+				},
+			},
+			givenRAIDType:  types.PoolRAIDTypeRAIDZ,
+			expectRAIDType: types.PoolRAIDTypeRAIDZ,
+			isErr:          false,
+		},
+		"no cache && mirror": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeMirror),
+						},
+					},
+				},
+			},
+			expectRAIDType: types.PoolRAIDTypeMirror,
+			isErr:          false,
+		},
+		"mirror cache": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeMirror),
+						},
+					},
+				},
+			},
+			givenRAIDType:  types.PoolRAIDTypeMirror,
+			expectRAIDType: types.PoolRAIDTypeMirror,
+			isErr:          false,
+		},
+		"no cache && stripe": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeStripe),
+						},
+					},
+				},
+			},
+			expectRAIDType: types.PoolRAIDTypeStripe,
+			isErr:          false,
+		},
+		"stripe cache": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"poolConfig": map[string]interface{}{
+							"raidType": string(types.PoolRAIDTypeStripe),
+						},
+					},
+				},
+			},
+			givenRAIDType:  types.PoolRAIDTypeStripe,
+			expectRAIDType: types.PoolRAIDTypeStripe,
+			isErr:          false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewHelper(mock.cstorClusterConfig)
+			h.raidType = mock.givenRAIDType
+			got, err := h.GetRAIDTypeOrCached()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if mock.isErr {
+				return
+			}
+			if got != mock.expectRAIDType {
+				t.Fatalf("Expected raid type %s got %s", mock.expectRAIDType, got)
+			}
+		})
+	}
+}
+
+func TestHelperGetLocalDiskSelector(t *testing.T) {
+	var tests = map[string]struct {
+		cstorClusterConfig *unstructured.Unstructured
+		expectSelector     metac.ResourceSelector
+		isErr              bool
+	}{
+		"nil cstor cluster config": {
+			cstorClusterConfig: nil,
+			expectSelector:     nilselector,
+			isErr:              true,
+		},
+		"nil cstor cluster config object": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: nil,
+			},
+			expectSelector: nilselector,
+			isErr:          true,
+		},
+		"invalid cstor cluster config": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Junk",
+				},
+			},
+			expectSelector: nilselector,
+			isErr:          true,
+		},
+		"cstor cluster config with valid kind": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+				},
+			},
+			expectSelector: nilselector,
+			isErr:          true,
+		},
+		"cstor cluster config && valid kind && remote disk": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"remote": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			expectSelector: nilselector,
+			isErr:          true,
+		},
+		"cstor cluster config && valid kind && nil local disk": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"local": nil,
+						},
+					},
+				},
+			},
+			expectSelector: nilselector,
+			isErr:          true,
+		},
+		"cstor cluster config && valid kind && nil selector terms": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"local": map[string]interface{}{
+								"blockDeviceSelector": map[string]interface{}{
+									"selectorTerms": nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectSelector: metac.ResourceSelector{
+				SelectorTerms: nil,
+			},
+			isErr: false,
+		},
+		"cstor cluster config && valid kind && empty selector terms": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"local": map[string]interface{}{
+								"blockDeviceSelector": map[string]interface{}{
+									"selectorTerms": []interface{}{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{},
+			},
+			isErr: false,
+		},
+		"cstor cluster config && valid kind && 1 empty item in selector terms": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"local": map[string]interface{}{
+								"blockDeviceSelector": map[string]interface{}{
+									"selectorTerms": []interface{}{
+										map[string]interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{{}},
+			},
+			isErr: false,
+		},
+		"cstor cluster config && valid kind && 1 empty matchslice in selector terms": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"local": map[string]interface{}{
+								"blockDeviceSelector": map[string]interface{}{
+									"selectorTerms": []interface{}{
+										map[string]interface{}{
+											"matchSlice": map[string]interface{}{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchSlice: map[string][]string{},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"cstor cluster config && valid kind && 1 nil matchslice in selector terms": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"local": map[string]interface{}{
+								"blockDeviceSelector": map[string]interface{}{
+									"selectorTerms": []interface{}{
+										map[string]interface{}{
+											"matchSlice": nil,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchSlice: nil,
+					},
+				},
+			},
+			isErr: false,
+		},
+		"cstor cluster config && valid kind && 1 matchslice in selector terms": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"local": map[string]interface{}{
+								"blockDeviceSelector": map[string]interface{}{
+									"selectorTerms": []interface{}{
+										map[string]interface{}{
+											"matchSlice": map[string][]interface{}{
+												"pool.items": []interface{}{"p0"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchSlice: map[string][]string{
+							"pool.items": []string{"p0"},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"cstor cluster config && valid kind && 1 matchsliceexp in selector terms": {
+			cstorClusterConfig: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorClusterConfig),
+					"spec": map[string]interface{}{
+						"diskConfig": map[string]interface{}{
+							"local": map[string]interface{}{
+								"blockDeviceSelector": map[string]interface{}{
+									"selectorTerms": []interface{}{
+										map[string]interface{}{
+											"matchSliceExpressions": []interface{}{
+												map[string]interface{}{
+													"key":      "pool.items",
+													"operator": "Equals",
+													"values":   []interface{}{"p0"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectSelector: metac.ResourceSelector{
+				SelectorTerms: []*metac.SelectorTerm{
+					&metac.SelectorTerm{
+						MatchSliceExpressions: []metac.SliceSelectorRequirement{
+							metac.SliceSelectorRequirement{
+								Key:      "pool.items",
+								Operator: metac.SliceSelectorOpEquals,
+								Values:   []string{"p0"},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewHelper(mock.cstorClusterConfig)
+			got, err := h.GetLocalBlockDeviceSelector()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !reflect.DeepEqual(got, mock.expectSelector) {
+				t.Fatalf("Expected no diff got\n%s",
+					cmp.Diff(got, mock.expectSelector),
+				)
+			}
+		})
+	}
+}

--- a/util/cstorpoolcluster/builder.go
+++ b/util/cstorpoolcluster/builder.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorpoolcluster
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+	stringutil "mayadata.io/cstorpoolauto/util/string"
+)
+
+// Builder helps building an unstructured instance of
+// kind CStorPoolCluster
+type Builder struct {
+	// Name of the desired CStorPoolCluster
+	Name string
+
+	// Namespace of the desired CStorPoolCluster
+	Namespace string
+
+	// OrderedHostNames represent an ordered list of host names
+	// that will be used to build a CStorPoolCluster instance
+	OrderedHostNames []string
+
+	// mapping of host name to block device names that are currently
+	// **observed** _(in existing CStorPoolCluster)_
+	HostNameToObservedDeviceNames map[string][]string
+
+	// mapping of host name to block device names that are **desired**
+	// _(present as available BlockDevices)_ & should participate in
+	// CStorPoolCluster formation
+	HostNameToDesiredDeviceNames map[string][]string
+
+	// annotations that should be used during building the desired
+	// CStorPoolCluster
+	DesiredAnnotations map[string]string
+
+	// labels that should be used during building the desired
+	// CStorPoolCluster
+	DesiredLabels map[string]string
+
+	// RAID type that should be used to form the desired
+	// CStorPoolCluster
+	DesiredRAIDType types.PoolRAIDType
+
+	// ordered and eligible hosts that will participate in formation
+	// of CStorPoolCluster
+	desiredOrderedHostNames []string
+
+	// maps the host name to devices by taking into consideration
+	// desired host names, observed devices & desired devices
+	hostNameToFinalDeviceNames map[string][]string
+
+	err error
+}
+
+// BuildOption is a functional approach to set various fields of
+// Builder instance
+type BuildOption func(*Builder) error
+
+// NewBuilder returns a new instance of Builder
+func NewBuilder(options ...BuildOption) *Builder {
+	b := &Builder{
+		HostNameToObservedDeviceNames: map[string][]string{},
+		HostNameToDesiredDeviceNames:  map[string][]string{},
+	}
+	for _, opt := range options {
+		err := opt(b)
+		if err != nil {
+			b.err = err
+			break
+		}
+	}
+	if b.err != nil {
+		return b
+	}
+	return b
+}
+
+func (b *Builder) setDefaultsIfNotSet() {
+	if b.HostNameToObservedDeviceNames == nil {
+		b.HostNameToObservedDeviceNames = map[string][]string{}
+	}
+	if b.HostNameToDesiredDeviceNames == nil {
+		b.HostNameToDesiredDeviceNames = map[string][]string{}
+	}
+	b.setOrderedHostNamesFromDesiredIfNotSet()
+	b.setDesiredOrderedHostNamesIfNotSet()
+	b.mapHostNameToFinalDeviceNamesIfNotSet()
+}
+
+func (b *Builder) setOrderedHostNamesFromDesiredIfNotSet() {
+	if len(b.OrderedHostNames) != 0 {
+		// nothing to do since it is already set
+		return
+	}
+	// build the desired hostnames that follows
+	// HostNameToDesiredDeviceNames
+	//
+	// NOTE:
+	//	Order is not guaranteed to be same everytime
+	// since this slice is populated from a map
+	for hostname := range b.HostNameToDesiredDeviceNames {
+		b.OrderedHostNames = append(b.OrderedHostNames, hostname)
+	}
+}
+
+func (b *Builder) setDesiredOrderedHostNamesIfNotSet() {
+	if len(b.desiredOrderedHostNames) != 0 {
+		// nothing to do since it is already set
+		return
+	}
+	for _, hostName := range b.OrderedHostNames {
+		if len(b.HostNameToDesiredDeviceNames[hostName]) == 0 {
+			// ignore this hostname if it is no more desired
+			// i.e. ignore this host if there there are no
+			// corresponding devices
+			continue
+		}
+		b.desiredOrderedHostNames =
+			append(b.desiredOrderedHostNames, hostName)
+	}
+}
+
+func (b *Builder) mapHostNameToFinalDeviceNamesIfNotSet() {
+	if len(b.hostNameToFinalDeviceNames) != 0 {
+		return
+	}
+	b.hostNameToFinalDeviceNames = map[string][]string{}
+	for hostName, desiredDeviceNames := range b.HostNameToDesiredDeviceNames {
+		if len(desiredDeviceNames) == 0 {
+			// no need to build the final device names against this host
+			// if there are no corresponding desired devices
+			continue
+		}
+		observedDeviceNames := b.HostNameToObservedDeviceNames[hostName]
+		// merge desired against the observed device names by keeping the order
+		// of observed device names
+		//
+		// NOTE:
+		//	This is very important logic that can reduce the disruptions to a pool.
+		// This is handled by placing the blockdevice name(s) at their old position(s).
+		b.hostNameToFinalDeviceNames[hostName] =
+			stringutil.NewEquality(observedDeviceNames, desiredDeviceNames).Merge()
+	}
+}
+
+func (b *Builder) validate() {
+	// simple validations
+	if b.Name == "" {
+		b.err = errors.Errorf("Can't build desired CStorPoolCluster: Missing name")
+		return
+	}
+	if b.Namespace == "" {
+		b.err = errors.Errorf("Can't build desired CStorPoolCluster: Missing namespace")
+		return
+	}
+	if b.DesiredRAIDType == "" {
+		b.err = errors.Errorf("Can't build desired CStorPoolCluster: Missing raid type")
+		return
+	}
+	b.validateDiskCount()
+}
+
+func (b *Builder) validateDiskCount() {
+	var errMsgs []string
+	diskCountByRAIDType :=
+		int(types.RAIDTypeToDefaultMinDiskCount[b.DesiredRAIDType])
+	for hostName, devices := range b.hostNameToFinalDeviceNames {
+		if len(devices)%diskCountByRAIDType != 0 {
+			errMsgs = append(errMsgs, fmt.Sprintf(
+				"Invalid disk count %d w.r.t RAID %q on host %q",
+				len(devices), b.DesiredRAIDType, hostName,
+			))
+		}
+	}
+	if len(errMsgs) != 0 {
+		b.err = errors.Errorf("Validation failed: [%s]", strings.Join(errMsgs, ", "))
+	}
+}
+
+// buildDesiredRAIDGroupsByHostName builds that fragment of the
+// CStorPoolCluster spec that deals with raid groups.
+// The resulting fragment is based on the given node name.
+func (b *Builder) buildDesiredRAIDGroupsByHostName(nodeName string) []interface{} {
+	// local function to build blockdevice sections per raid group
+	buildBlockDevices := func(deviceNames []string) []interface{} {
+		var blockDevices []interface{}
+		for _, deviceName := range deviceNames {
+			blockDevices = append(
+				blockDevices, map[string]interface{}{
+					"blockDeviceName": deviceName,
+				},
+			)
+		}
+		return blockDevices
+	}
+	// local function to build a raid group
+	buildSingleRAIDGroup := func(deviceNames []string) interface{} {
+		return map[string]interface{}{
+			"type":         string(b.DesiredRAIDType),
+			"isWriteCache": false,
+			"isSpare":      false,
+			"isReadCache":  false,
+			"blockDevices": buildBlockDevices(deviceNames),
+		}
+	}
+	// local function to build all raid groups within a node/pool
+	buildAllRAIDGroupsPerHost := func(deviceNames []string) []interface{} {
+		var raidGroupList []interface{}
+		var raidGroup []string
+
+		diskCountByRAIDType :=
+			int(types.RAIDTypeToDefaultMinDiskCount[b.DesiredRAIDType])
+		for idx, deviceName := range deviceNames {
+			raidGroup = append(raidGroup, deviceName)
+			// Following logic takes care of distributing disks based
+			// on RAID type.
+			//
+			// NOTE:
+			//	Disks get distributed as follows:
+			// 	- Mirror has 2 disks per raid group
+			//	- RAIDZ has 3 disks per raid group
+			//  - RAIDZ2 has 6 disks per raid group
+			//  - Stripe has 1 disk per raid group
+			if (idx+1)%diskCountByRAIDType == 0 {
+				raidGroupList = append(raidGroupList, buildSingleRAIDGroup(raidGroup))
+				// reset the raidGroup to make way to build next raidGroup for this pool
+				raidGroup = nil
+			}
+		}
+		return raidGroupList
+	}
+	return buildAllRAIDGroupsPerHost(b.hostNameToFinalDeviceNames[nodeName])
+}
+
+// buildDesiredPoolByHostName builds that fragment of CStorPoolCluster
+// that deals with specifying a single pool instance. The resulting
+// fragment is based on the given node name.
+func (b *Builder) buildDesiredPoolByHostName(hostName string) interface{} {
+	return map[string]interface{}{
+		"nodeSelector": map[string]interface{}{
+			"kubernetes.io/hostname": hostName,
+		},
+		"raidGroups": b.buildDesiredRAIDGroupsByHostName(hostName),
+		"poolConfig": map[string]interface{}{
+			"defaultRaidGroupType": string(b.DesiredRAIDType),
+			"overProvisioning":     false,
+			"compression":          "off",
+		},
+	}
+}
+
+// buildDesiredPools builds that fragment of CStorPoolCluster
+// that deals with specifying all the desired pool instances.
+func (b *Builder) buildDesiredPools() []interface{} {
+	var pools []interface{}
+	for _, hostName := range b.desiredOrderedHostNames {
+		pool := b.buildDesiredPoolByHostName(hostName)
+		pools = append(pools, pool)
+	}
+	return pools
+}
+
+// BuildDesiredState builds the desired CStorPoolCluster based on
+// observed & desired block device names
+func (b *Builder) BuildDesiredState() (*unstructured.Unstructured, error) {
+	// set the defaults before proceeding to create the desired state
+	b.setDefaultsIfNotSet()
+	// run some validation checks
+	b.validate()
+	// check for any build or validation errors
+	if b.err != nil {
+		return nil, b.err
+	}
+	// start constructing the desired state
+	cspc := &unstructured.Unstructured{}
+	cspc.SetUnstructuredContent(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":      b.Name,
+			"namespace": b.Namespace,
+		},
+		"spec": map[string]interface{}{
+			"pools": b.buildDesiredPools(),
+		},
+	})
+	if len(b.DesiredAnnotations) != 0 {
+		cspc.SetAnnotations(b.DesiredAnnotations)
+	}
+	if len(b.DesiredLabels) != 0 {
+		cspc.SetLabels(b.DesiredLabels)
+	}
+	// below is the right way to set APIVersion & Kind
+	cspc.SetAPIVersion(string(types.APIVersionOpenEBSV1Alpha1))
+	cspc.SetKind(string(types.KindCStorPoolCluster))
+	return cspc, nil
+}

--- a/util/cstorpoolcluster/builder_test.go
+++ b/util/cstorpoolcluster/builder_test.go
@@ -1,0 +1,861 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorpoolcluster
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+)
+
+func TestNewBuilder(t *testing.T) {
+	var tests = map[string]struct {
+		opts  []BuildOption
+		isErr bool
+	}{
+		"no build options": {
+			opts:  []BuildOption{},
+			isErr: false,
+		},
+		"1 noop build options": {
+			opts: []BuildOption{
+				func(b *Builder) error {
+					return nil
+				},
+			},
+			isErr: false,
+		},
+		"2 noop build options": {
+			opts: []BuildOption{
+				func(b *Builder) error {
+					return nil
+				},
+				func(b *Builder) error {
+					return nil
+				},
+			},
+			isErr: false,
+		},
+		"1 build option that returns error": {
+			opts: []BuildOption{
+				func(b *Builder) error {
+					return errors.Errorf("err")
+				},
+			},
+			isErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			b := NewBuilder(mock.opts...)
+			if mock.isErr && b.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && b.err != nil {
+				t.Fatalf("Expected no error got [%+v]", b.err)
+			}
+		})
+	}
+}
+
+func TestBuilderBuildDesiredState(t *testing.T) {
+	var tests = map[string]struct {
+		builder *Builder
+		expect  *unstructured.Unstructured
+		isErr   bool
+	}{
+		"missing name": {
+			builder: &Builder{},
+			isErr:   true,
+		},
+		"missing namespace": {
+			builder: &Builder{
+				Name: "test",
+			},
+			isErr: true,
+		},
+		"missing raid type": {
+			builder: &Builder{
+				Name:      "test",
+				Namespace: "test",
+			},
+			isErr: true,
+		},
+		"mirror with 1 host & 1 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeMirror,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1"},
+				},
+			},
+			isErr: true,
+		},
+		"mirror with 1 host & 3 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeMirror,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2", "bd3"},
+				},
+			},
+			isErr: true,
+		},
+		"raidz with 1 host & 1 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1"},
+				},
+			},
+			isErr: true,
+		},
+		"raidz with 1 host & 4 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2", "bd3", "bd4"},
+				},
+			},
+			isErr: true,
+		},
+		"raidz2 with 1 host & 2 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2"},
+				},
+			},
+			isErr: true,
+		},
+		"raidz2 with 1 host & 5 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2", "bd3", "bd4", "bd5"},
+				},
+			},
+			isErr: true,
+		},
+		"raidz2 with 2 hosts & one host with 6 disks & other with 5 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2", "bd3", "bd4", "bd5", "bd6"},
+					"node-002": []string{"bd21", "bd22", "bd23", "bd24", "bd25"},
+				},
+			},
+			isErr: true,
+		},
+		"no observed block devices && no observed cspc": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeMirror,
+			},
+			expect: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}(nil),
+					},
+				},
+			},
+			isErr: false,
+		},
+		"1 node && 2 desired block devices && no observed cspc devices": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeMirror,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2"},
+				},
+			},
+			expect: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd1",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd2",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"1 node && stripe && 1 new block device && 1 observed cspc device": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeStripe,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2"}, // bd2 is new
+				},
+				HostNameToObservedDeviceNames: map[string][]string{
+					"node-001": []string{"bd1"}, // bd1 is existing
+				},
+			},
+			expect: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "stripe",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd1",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd2",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"1 node && stripe && 1 new, 1 remove block device && 2 observed cspc devices": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeStripe,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd3"}, // bd3 is new
+				},
+				HostNameToObservedDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2"}, // bd1 & bd2 are existing
+				},
+			},
+			expect: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "stripe",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd1",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd3",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"2 nodes && stripe && 1 new, 1 remove block device && 2 observed cspc devices": {
+			builder: &Builder{
+				Name:             "test",
+				Namespace:        "test",
+				DesiredRAIDType:  types.PoolRAIDTypeStripe,
+				OrderedHostNames: []string{"node-002", "node-001"}, // reversed order
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd3"},   // bd3 is new
+					"node-002": []string{"bd21", "bd23"}, // bd23 is new
+				},
+				HostNameToObservedDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2"},   // bd1 & bd2 are existing
+					"node-002": []string{"bd21", "bd22"}, // bd21 & bd22 are existing
+				},
+			},
+			expect: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "stripe",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd21",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd23",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "stripe",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd1",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd3",
+											},
+										},
+										"type":         "stripe",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"2 nodes && mirror && 1 new, 1 remove block device && 2 observed cspc devices": {
+			builder: &Builder{
+				Name:             "test",
+				Namespace:        "test",
+				DesiredRAIDType:  types.PoolRAIDTypeMirror,
+				OrderedHostNames: []string{"node-001", "node-002"},
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd3"},   // bd3 is new
+					"node-002": []string{"bd21", "bd23"}, // bd23 is new
+				},
+				HostNameToObservedDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2"},   // bd1 & bd2 are existing
+					"node-002": []string{"bd21", "bd22"}, // bd21 & bd22 are existing
+				},
+			},
+			expect: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd1",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd3",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd21",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd23",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"1 nodes && mirror && 2 new, 1 remove block device && 2 observed cspc devices": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeMirror,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd3", "bd4"}, // bd3 & bd4 are new
+				},
+				HostNameToObservedDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2"}, // bd1 & bd2 are existing
+				},
+			},
+			isErr: true,
+		},
+		"1 node && mirror && 1 remove block device && 3 observed cspc devices": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeMirror,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd3"}, // bd2 is removed
+				},
+				HostNameToObservedDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2", "bd3"}, // bd1, bd2 & bd3 are existing
+				},
+			},
+			expect: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd1",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd3",
+											},
+										},
+										"type":         "mirror",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"1 node && raidz && 2 new block devices && 1 observed cspc devices": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd3", "bd4"}, // bd3 & bd4 are new
+				},
+				HostNameToObservedDeviceNames: map[string][]string{
+					"node-001": []string{"bd1"}, // bd1 is existing
+				},
+			},
+			isErr: true,
+		},
+		"1 node && raidz && 3 new block devices && 1 observed cspc devices": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2", "bd3", "bd4"}, // bd2, bd3 & bd4 are new
+				},
+				HostNameToObservedDeviceNames: map[string][]string{
+					"node-001": []string{"bd1"}, // bd1 is existing
+				},
+			},
+			isErr: true,
+		},
+		"1 node && raidz2 && 3 new block devices && 1 observed cspc devices": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ2,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2", "bd3", "bd4"}, // bd2, bd3 & bd4 are new
+				},
+				HostNameToObservedDeviceNames: map[string][]string{
+					"node-001": []string{"bd1"}, // bd1 is existing
+				},
+			},
+			isErr: true,
+		},
+		"1 node && raidz2 && 5 new block devices && 1 observed cspc devices": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ2,
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2", "bd3", "bd4", "bd5", "bd6"},
+				},
+				HostNameToObservedDeviceNames: map[string][]string{
+					"node-001": []string{"bd1"}, // bd1 is existing
+				},
+			},
+			expect: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "raidz2",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd1",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd2",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd3",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd4",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd5",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd6",
+											},
+										},
+										"type":         "raidz2",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+		"2 nodes && raidz2 && 5 new block devices && 1 observed cspc devices": {
+			builder: &Builder{
+				Name:             "test",
+				Namespace:        "test",
+				DesiredRAIDType:  types.PoolRAIDTypeRAIDZ2,
+				OrderedHostNames: []string{"node-002", "node-001"},
+				HostNameToDesiredDeviceNames: map[string][]string{
+					"node-001": []string{"bd1", "bd2", "bd3", "bd4", "bd5", "bd6"},
+					"node-002": []string{"bd21", "bd22", "bd23", "bd24", "bd25", "bd26"},
+				},
+				HostNameToObservedDeviceNames: map[string][]string{
+					"node-001": []string{"bd1"},  // bd1 is existing
+					"node-002": []string{"bd21"}, // bd21 is existing
+				},
+			},
+			expect: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       string(types.KindCStorPoolCluster),
+					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+					},
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "raidz2",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd21",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd22",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd23",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd24",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd25",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd26",
+											},
+										},
+										"type":         "raidz2",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "raidz2",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd1",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd2",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd3",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd4",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd5",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd6",
+											},
+										},
+										"type":         "raidz2",
+										"isWriteCache": false,
+										"isSpare":      false,
+										"isReadCache":  false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder
+			got, err := b.BuildDesiredState()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none: [%+v]", b)
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if !reflect.DeepEqual(got, mock.expect) {
+				t.Fatalf("Expected no diff got\n%s", cmp.Diff(got, mock.expect))
+			}
+		})
+	}
+}

--- a/util/cstorpoolcluster/helper.go
+++ b/util/cstorpoolcluster/helper.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorpoolcluster
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+	"mayadata.io/cstorpoolauto/unstruct"
+)
+
+// Helper exposes utility methods w.r.t BlockDevice unstructured
+// instance
+type Helper struct {
+	CStorPoolCluster *unstructured.Unstructured
+
+	allHostNames               []string
+	hostNameToBlockDeviceNames map[string][]string
+	err                        error
+}
+
+// NewHelper returns a new instance of CStorClusterConfig based helper
+func NewHelper(obj *unstructured.Unstructured) *Helper {
+	var err error
+	if obj == nil {
+		err = errors.Errorf("Can't init cspc helper: Nil obj")
+	} else if obj.GetKind() != string(types.KindCStorPoolCluster) {
+		err = errors.Errorf(
+			"Can't init cspc helper: Want %q got %q",
+			string(types.KindCStorPoolCluster), obj.GetKind(),
+		)
+	}
+	if err != nil {
+		return &Helper{
+			err: err,
+		}
+	}
+	return &Helper{
+		CStorPoolCluster: obj,
+	}
+}
+
+// GetOrderedHostNames returns all hostname(s) associated with
+// this CStorPoolCluster unstructured instance in the same order
+// they are found at observed CSPC specs
+func (h *Helper) GetOrderedHostNames() ([]string, error) {
+	if h.err != nil {
+		return nil, h.err
+	}
+	var allHostNames []string
+	// local function to get the host name
+	getNodeName := func(obj *unstructured.Unstructured) error {
+		hostname, err :=
+			unstruct.GetStringOrError(
+				obj, "spec", "nodeSelector", "kubernetes.io/hostname",
+			)
+		if err != nil {
+			return err
+		}
+		allHostNames = append(allHostNames, hostname)
+		return nil
+	}
+	// logic starts here
+	pools, err := unstruct.GetSliceOrError(h.CStorPoolCluster, "spec", "pools")
+	if err != nil {
+		return nil, err
+	}
+	// Below will iterate through the pools & run following
+	// getNodeName callback against each iterated pool
+	err = unstruct.SliceIterator(pools).ForEach(getNodeName)
+	if err != nil {
+		return nil, err
+	}
+	h.allHostNames = allHostNames
+	return h.allHostNames, nil
+}
+
+// GetOrderedHostNamesOrCached returns all hostname(s) associated
+// with this CStorPoolCluster unstructured instance
+func (h *Helper) GetOrderedHostNamesOrCached() ([]string, error) {
+	if h.err != nil {
+		return nil, h.err
+	}
+	if len(h.allHostNames) == 0 {
+		// don't use the cache
+		return h.GetOrderedHostNames()
+	}
+	// return the cached copy
+	return h.allHostNames, nil
+}
+
+// GroupBlockDeviceNamesByHostName maps hostname to corresponding block
+// device names & returns this mapping
+func (h *Helper) GroupBlockDeviceNamesByHostName() (map[string][]string, error) {
+	if h.err != nil {
+		return nil, h.err
+	}
+	// currentNodeName holds the current node name of the
+	// CStorPoolCluster nodes that are under iteration
+	var currentNodeName string
+	h.hostNameToBlockDeviceNames = map[string][]string{}
+
+	// local function to get the host name
+	getNodeName := func(obj *unstructured.Unstructured) (err error) {
+		currentNodeName, err =
+			unstruct.GetStringOrError(obj, "spec", "nodeSelector", "kubernetes.io/hostname")
+		return
+	}
+	// local function to get the blockdevice name
+	getBlockDeviceName := func(obj *unstructured.Unstructured) error {
+		deviceName, err := unstruct.GetStringOrError(obj, "spec", "blockDeviceName")
+		if err != nil {
+			return err
+		}
+		// map the current iterated nodename with current iterated
+		// block device name
+		h.hostNameToBlockDeviceNames[currentNodeName] =
+			append(h.hostNameToBlockDeviceNames[currentNodeName], deviceName)
+		return nil
+	}
+	// local function to get blockdevices per raid group
+	getBlockDevicesPerRAIDGroup := func(obj *unstructured.Unstructured) error {
+		blockDevices, err := unstruct.GetSliceOrError(obj, "spec", "blockDevices")
+		if err != nil {
+			return err
+		}
+		// iterate through each blockdevice
+		return unstruct.SliceIterator(blockDevices).ForEach(getBlockDeviceName)
+	}
+	// local function to get blockdevices per pool
+	getBlockDevicesPerPool := func(obj *unstructured.Unstructured) error {
+		raidGroups, err := unstruct.GetSliceOrError(obj, "spec", "raidGroups")
+		if err != nil {
+			return err
+		}
+		// iterate through each raidgroup
+		return unstruct.SliceIterator(raidGroups).ForEach(getBlockDevicesPerRAIDGroup)
+	}
+	// logic starts here
+	pools, err := unstruct.GetSliceOrError(h.CStorPoolCluster, "spec", "pools")
+	if err != nil {
+		return nil, err
+	}
+	// Below iteration will iterate pools & run following
+	// callbacks against each iterated pool:
+	//
+	//	1/ getNodeName &
+	// 	2/ getBlockDevicesPerPool
+	//
+	// NOTE:
+	// 	One of the local functions maps the node name
+	// against corresponding blockdevice names.
+	err = unstruct.SliceIterator(pools).ForEach(
+		getNodeName,
+		getBlockDevicesPerPool,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return h.hostNameToBlockDeviceNames, nil
+}
+
+// GroupBlockDeviceNamesByHostNameOrCached maps hostname to
+// corresponding block device names & returns this mapping
+func (h *Helper) GroupBlockDeviceNamesByHostNameOrCached() (map[string][]string, error) {
+	if h.err != nil {
+		return nil, h.err
+	}
+	if len(h.hostNameToBlockDeviceNames) == 0 {
+		// dont use the cache
+		return h.GroupBlockDeviceNamesByHostName()
+	}
+	for name, devices := range h.hostNameToBlockDeviceNames {
+		if name == "" || len(devices) == 0 {
+			// dont use the cache
+			return h.GroupBlockDeviceNamesByHostName()
+		}
+	}
+	// return the cached copy
+	return h.hostNameToBlockDeviceNames, nil
+}

--- a/util/cstorpoolcluster/helper_test.go
+++ b/util/cstorpoolcluster/helper_test.go
@@ -1,0 +1,498 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorpoolcluster
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+	stringutil "mayadata.io/cstorpoolauto/util/string"
+)
+
+func TestNewHelper(t *testing.T) {
+	var tests = map[string]struct {
+		obj   *unstructured.Unstructured
+		isErr bool
+	}{
+		"cspc kind": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorPoolCluster),
+				},
+			},
+			isErr: false,
+		},
+		"invalid kind": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "InValid",
+				},
+			},
+			isErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewHelper(mock.obj)
+			if mock.isErr && h.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && h.err != nil {
+				t.Fatalf("Expected no error got [%+v]", h.err)
+			}
+		})
+	}
+}
+
+func TestHelperGetAllHostNames(t *testing.T) {
+	var tests = map[string]struct {
+		obj    *unstructured.Unstructured
+		expect []string
+		isErr  bool
+	}{
+		"cspc kind - no data": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorPoolCluster),
+				},
+			},
+			isErr: true,
+		},
+		"invalid kind": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "InValid",
+				},
+			},
+			isErr: true,
+		},
+		"cspc kind - 2 pools - full blown specs": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorPoolCluster),
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							// pool on node-001
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								// 3 raidGroups per pool
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd11",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd12",
+											},
+										},
+										"type": "mirror",
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd13",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd14",
+											},
+										},
+										"type": "mirror",
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd15",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd16",
+											},
+										},
+										"type": "mirror",
+									},
+								},
+							},
+							// pool on node-002
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+								// 3 raidGroups per pool
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd21",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd22",
+											},
+										},
+										"type": "mirror",
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd23",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd24",
+											},
+										},
+										"type": "mirror",
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd25",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd26",
+											},
+										},
+										"type": "mirror",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr:  false,
+			expect: []string{"node-001", "node-002"},
+		},
+		"cspc kind - 1 pool": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorPoolCluster),
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							// pool on node-001
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								"raidGroups": []interface{}{},
+							},
+						},
+					},
+				},
+			},
+			isErr:  false,
+			expect: []string{"node-001"},
+		},
+		"cspc kind - 0 pool": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorPoolCluster),
+					"spec": map[string]interface{}{
+						"pools": []interface{}{},
+					},
+				},
+			},
+			isErr: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewHelper(mock.obj)
+			got, err := h.GetOrderedHostNames()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if stringutil.NewEquality(got, mock.expect).IsDiff() {
+				t.Fatalf("Expected no diff got diff: got [%+v]", got)
+			}
+		})
+	}
+}
+
+func TestHelperGetAllHostNamesOrCached(t *testing.T) {
+	var tests = map[string]struct {
+		cached []string
+		expect []string
+		isErr  bool
+	}{
+		"cspc - 1 cached host": {
+			cached: []string{"node-001"},
+			expect: []string{"node-001"},
+			isErr:  false,
+		},
+		"cspc - 2 cached hosts": {
+			cached: []string{"node-001", "node-002"},
+			expect: []string{"node-001", "node-002"},
+			isErr:  false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := &Helper{
+				allHostNames: mock.cached,
+			}
+			got, err := h.GetOrderedHostNamesOrCached()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if stringutil.NewEquality(got, mock.expect).IsDiff() {
+				t.Fatalf("Expected no diff got diff: got [%+v]", got)
+			}
+		})
+	}
+}
+
+func TestHelperGroupBlockDeviceNamesByHostName(t *testing.T) {
+	var tests = map[string]struct {
+		obj    *unstructured.Unstructured
+		expect map[string][]string
+		isErr  bool
+	}{
+		"cspc kind - 2 pools - full blown specs": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": string(types.KindCStorPoolCluster),
+					"spec": map[string]interface{}{
+						"pools": []interface{}{
+							// pool on node-001
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-001",
+								},
+								// 3 raidGroups per pool
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd11",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd12",
+											},
+										},
+										"type": "mirror",
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd13",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd14",
+											},
+										},
+										"type": "mirror",
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd15",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd16",
+											},
+										},
+										"type": "mirror",
+									},
+								},
+							},
+							// pool on node-002
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-002",
+								},
+								// 2 raidGroups per pool
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd21",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd22",
+											},
+										},
+										"type": "mirror",
+									},
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd23",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd24",
+											},
+										},
+										"type": "mirror",
+									},
+								},
+							},
+							// pool on node-003
+							map[string]interface{}{
+								"poolConfig": map[string]interface{}{
+									"defaultRaidGroupType": "mirror",
+									"overProvisioning":     false,
+									"compression":          "off",
+								},
+								"nodeSelector": map[string]interface{}{
+									"kubernetes.io/hostname": "node-003",
+								},
+								// 1 raidGroups per pool
+								"raidGroups": []interface{}{
+									map[string]interface{}{
+										"blockDevices": []interface{}{
+											map[string]interface{}{
+												"blockDeviceName": "bd31",
+											},
+											map[string]interface{}{
+												"blockDeviceName": "bd32",
+											},
+										},
+										"type": "mirror",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			isErr: false,
+			expect: map[string][]string{
+				"node-001": []string{"bd11", "bd12", "bd13", "bd14", "bd15", "bd16"},
+				"node-002": []string{"bd21", "bd22", "bd23", "bd24"},
+				"node-003": []string{"bd31", "bd32"},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := NewHelper(mock.obj)
+			got, err := h.GroupBlockDeviceNamesByHostName()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if len(mock.expect) != len(got) {
+				t.Fatalf("Expected count %d got %d", len(mock.expect), len(got))
+			}
+			for host, expectDevices := range mock.expect {
+				gotDevices := got[host]
+				if stringutil.NewEquality(gotDevices, expectDevices).IsDiff() {
+					t.Fatalf(
+						"Expected no diff:\nhost %q\ngot devices [%+v]\nexpect devices [%+v]",
+						host, gotDevices, expectDevices,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestHelperGroupBlockDeviceNamesByHostNameOrCached(t *testing.T) {
+	var tests = map[string]struct {
+		cached map[string][]string
+		expect map[string][]string
+		isErr  bool
+	}{
+		"cspc - 1 cached host": {
+			cached: map[string][]string{
+				"node-001": []string{"bd1"},
+			},
+			expect: map[string][]string{
+				"node-001": []string{"bd1"},
+			},
+			isErr: false,
+		},
+		"cspc - 2 cached hosts": {
+			cached: map[string][]string{
+				"node-001": []string{"bd1"},
+				"node-002": []string{"bd2"},
+			},
+			expect: map[string][]string{
+				"node-001": []string{"bd1"},
+				"node-002": []string{"bd2"},
+			},
+			isErr: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			h := &Helper{
+				hostNameToBlockDeviceNames: mock.cached,
+			}
+			got, err := h.GroupBlockDeviceNamesByHostNameOrCached()
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+			if len(mock.expect) != len(got) {
+				t.Fatalf("Expected count %d got %d", len(mock.expect), len(got))
+			}
+			for host, expectDevices := range mock.expect {
+				gotDevices := got[host]
+				if stringutil.NewEquality(gotDevices, expectDevices).IsDiff() {
+					t.Fatalf(
+						"Expected no diff:\nhost %q\ngot devices [%+v]\nexpect devices [%+v]",
+						host, gotDevices, expectDevices,
+					)
+				}
+			}
+		})
+	}
+}

--- a/util/metac/validation.go
+++ b/util/metac/validation.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metac
+
+import (
+	"github.com/pkg/errors"
+	"openebs.io/metac/controller/generic"
+)
+
+// ValidateGenericControllerArgs validates the given request &
+// response
+func ValidateGenericControllerArgs(
+	request *generic.SyncHookRequest, response *generic.SyncHookResponse,
+) error {
+	if request == nil {
+		return errors.Errorf("Invalid gctl args: Nil request")
+	}
+	if request.Watch == nil || request.Watch.Object == nil {
+		return errors.Errorf("Invalid gctl args: Nil watch")
+	}
+	if response == nil {
+		return errors.Errorf("Invalid gctl args: Nil response")
+	}
+	// a valid request & response
+	return nil
+}

--- a/util/metac/validation_test.go
+++ b/util/metac/validation_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metac
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"openebs.io/metac/controller/generic"
+)
+
+func TestValidateGenericControllerArgs(t *testing.T) {
+	var tests = map[string]struct {
+		request  *generic.SyncHookRequest
+		response *generic.SyncHookResponse
+		isErr    bool
+	}{
+		"nil request": {
+			isErr: true,
+		},
+		"nil request watch": {
+			request: &generic.SyncHookRequest{},
+			isErr:   true,
+		},
+		"nil request watch object": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{},
+			},
+			isErr: true,
+		},
+		"nil response": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+			},
+			isErr: true,
+		},
+		"not nil request, watch & response": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+			},
+			response: &generic.SyncHookResponse{},
+			isErr:    false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			err := ValidateGenericControllerArgs(mock.request, mock.response)
+			if mock.isErr && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && err != nil {
+				t.Fatalf("Expected no error got [%+v]", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds logic to consider block devices that are already discovered in one or more worker nodes. This logic considers these block devices based on the labels assigned to these devices. They are then used to form a CStorPoolCluster resource in Kubernetes.

In addition, there are several bug fixes done due to extensive implementation of unit tests across several packages.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>