### PR TITLE
fix(recommendation): fix the device recommendation logic and update the recommendation structure

### DIFF
--- a/pkg/recommendation/device.go
+++ b/pkg/recommendation/device.go
@@ -209,7 +209,7 @@ func (cbd capacityBlockDevices) getPoolInstance(requestedCapacity int64, raidCon
 		// contains both 50GB and 100GB of block devices.
 		// This will break the loop once suitable block device is found and return the last block devices.
 		// In this case 100GB.
-		if len(prevDataDevices) != 0 && (requestedCapacity < capacity) {
+		if len(prevDataDevices) != 0 && (requestedCapacity <= capacity) {
 			break
 		}
 

--- a/pkg/recommendation/device_test.go
+++ b/pkg/recommendation/device_test.go
@@ -24,7 +24,7 @@ func TestGetRecommendation(t *testing.T) {
 					Spec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
+							RAIDType:         types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
 						},
 					},
@@ -41,7 +41,7 @@ func TestGetRecommendation(t *testing.T) {
 					Spec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
+							RAIDType:         types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 1,
 						},
 					},
@@ -93,7 +93,7 @@ func TestGetRecommendation(t *testing.T) {
 					Spec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
+							RAIDType:         types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
 						},
 					},
@@ -145,7 +145,7 @@ func TestGetRecommendation(t *testing.T) {
 					Spec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
+							RAIDType:         types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
 						},
 					},
@@ -195,7 +195,7 @@ func TestGetRecommendation(t *testing.T) {
 					Spec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
+							RAIDType:         types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
 						},
 					},
@@ -278,7 +278,7 @@ func TestGetRecommendation(t *testing.T) {
 					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
+							RAIDType:         types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
 						},
 					},
@@ -319,7 +319,7 @@ func TestGetRecommendation(t *testing.T) {
 					Spec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeRAIDZ,
+							RAIDType:         types.PoolRAIDTypeRAIDZ,
 							GroupDeviceCount: 3,
 						},
 					},
@@ -405,7 +405,7 @@ func TestGetRecommendation(t *testing.T) {
 					Spec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
+							RAIDType:         types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
 						},
 					},
@@ -491,7 +491,7 @@ func TestGetRecommendation(t *testing.T) {
 					Spec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
+							RAIDType:         types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
 						},
 					},
@@ -574,7 +574,7 @@ func TestGetRecommendation(t *testing.T) {
 					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
+							RAIDType:         types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
 						},
 					},
@@ -615,7 +615,7 @@ func TestGetRecommendation(t *testing.T) {
 					Spec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
+							RAIDType:         types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
 						},
 					},
@@ -764,7 +764,7 @@ func TestGetRecommendation(t *testing.T) {
 					RequestSpec: types.CStorPoolClusterRecommendationRequestSpec{
 						PoolCapacity: poolCapacity,
 						DataConfig: types.RaidGroupConfig{
-							Type:             types.PoolRAIDTypeMirror,
+							RAIDType:         types.PoolRAIDTypeMirror,
 							GroupDeviceCount: 2,
 						},
 					},
@@ -838,7 +838,7 @@ func TestNewRequestForDevice(t *testing.T) {
 				Spec: types.CStorPoolClusterRecommendationRequestSpec{
 					PoolCapacity: poolCapacity,
 					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeMirror,
+						RAIDType:         types.PoolRAIDTypeMirror,
 						GroupDeviceCount: 2,
 					},
 				},
@@ -853,7 +853,7 @@ func TestNewRequestForDevice(t *testing.T) {
 				Spec: types.CStorPoolClusterRecommendationRequestSpec{
 					PoolCapacity: poolCapacity,
 					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeMirror,
+						RAIDType:         types.PoolRAIDTypeMirror,
 						GroupDeviceCount: 0,
 					},
 				},
@@ -903,7 +903,7 @@ func TestNewRequestForDevice(t *testing.T) {
 				Spec: types.CStorPoolClusterRecommendationRequestSpec{
 					PoolCapacity: poolCapacity,
 					DataConfig: types.RaidGroupConfig{
-						Type:             types.PoolRAIDTypeMirror,
+						RAIDType:         types.PoolRAIDTypeMirror,
 						GroupDeviceCount: 2,
 					},
 				},

--- a/types/raidgroupconfig.go
+++ b/types/raidgroupconfig.go
@@ -23,7 +23,7 @@ import "github.com/pkg/errors"
 type RaidGroupConfig struct {
 	// Type is the raid group type
 	// Supported values are : stripe, mirror, raidz and raidz2
-	Type PoolRAIDType `json:"raidType"`
+	RAIDType PoolRAIDType `json:"raidType"`
 	// GroupDeviceCount contains device count in a raid group
 	// -- for stripe DeviceCount = 1
 	// -- for mirror DeviceCount = 2
@@ -37,7 +37,7 @@ type RaidGroupConfig struct {
 // type: mirror groupDeviceCount: 2
 func GetDefaultRaidGroupConfig() *RaidGroupConfig {
 	return &RaidGroupConfig{
-		Type:             PoolRAIDTypeDefault,
+		RAIDType:         PoolRAIDTypeDefault,
 		GroupDeviceCount: RAIDTypeToDefaultMinDiskCount[PoolRAIDTypeMirror],
 	}
 }
@@ -49,10 +49,10 @@ func (rgc *RaidGroupConfig) PopulateDefaultGroupDeviceCountIfNotPresent() error 
 	if rgc.GroupDeviceCount != 0 {
 		return nil
 	}
-	dc, ok := RAIDTypeToDefaultMinDiskCount[rgc.Type]
+	dc, ok := RAIDTypeToDefaultMinDiskCount[rgc.RAIDType]
 	if !ok {
 		return errors.Errorf("Invalid RAID type %q: Supports %q, %q, %q or %q.",
-			rgc.Type, PoolRAIDTypeStripe, PoolRAIDTypeMirror, PoolRAIDTypeRAIDZ, PoolRAIDTypeRAIDZ2)
+			rgc.RAIDType, PoolRAIDTypeStripe, PoolRAIDTypeMirror, PoolRAIDTypeRAIDZ, PoolRAIDTypeRAIDZ2)
 	}
 	rgc.GroupDeviceCount = dc
 	return nil
@@ -61,7 +61,7 @@ func (rgc *RaidGroupConfig) PopulateDefaultGroupDeviceCountIfNotPresent() error 
 // GetDataDeviceCount returns data device count for one raid group configuration
 // This is helpfull to calculate pool capacity.
 func (rgc *RaidGroupConfig) GetDataDeviceCount() int64 {
-	switch rgc.Type {
+	switch rgc.RAIDType {
 	case PoolRAIDTypeMirror:
 		return rgc.GroupDeviceCount / 2
 	// For stripe pool data device count in is n.
@@ -86,13 +86,13 @@ func (rgc *RaidGroupConfig) Validate() error {
 	// If we got any -ve number or 0 then it an invalid device count.
 	if rgc.GroupDeviceCount <= 0 {
 		return errors.Errorf("Invalid device count %d for RAID type %q.",
-			rgc.GroupDeviceCount, rgc.Type)
+			rgc.GroupDeviceCount, rgc.RAIDType)
 	}
 
-	minDeviceCount, ok := RAIDTypeToDefaultMinDiskCount[PoolRAIDType(rgc.Type)]
+	minDeviceCount, ok := RAIDTypeToDefaultMinDiskCount[PoolRAIDType(rgc.RAIDType)]
 	if !ok {
 		return errors.Errorf("Invalid RAID type %q: Supports %q, %q, %q or %q.",
-			rgc.Type, PoolRAIDTypeStripe, PoolRAIDTypeMirror, PoolRAIDTypeRAIDZ, PoolRAIDTypeRAIDZ2)
+			rgc.RAIDType, PoolRAIDTypeStripe, PoolRAIDTypeMirror, PoolRAIDTypeRAIDZ, PoolRAIDTypeRAIDZ2)
 	}
 
 	// If device count is less than min device count then that is not a valid
@@ -101,16 +101,16 @@ func (rgc *RaidGroupConfig) Validate() error {
 	// count 2 is valid if n=0 but that is not a valid raid group config.
 	if minDeviceCount > rgc.GroupDeviceCount {
 		return errors.Errorf("Invalid device count %d for RAID type %q",
-			rgc.GroupDeviceCount, rgc.Type)
+			rgc.GroupDeviceCount, rgc.RAIDType)
 	}
 
-	switch rgc.Type {
+	switch rgc.RAIDType {
 	// For mirror pool device count in one vdev is 2
 	case PoolRAIDTypeMirror:
 		{
 			if rgc.GroupDeviceCount != 2 {
 				return errors.Errorf("Invalid device count %d for RAID type %q: Want 2.",
-					rgc.GroupDeviceCount, rgc.Type)
+					rgc.GroupDeviceCount, rgc.RAIDType)
 			}
 		}
 	// For stripe pool device count in one vdev is n. Where n > 0
@@ -126,7 +126,7 @@ func (rgc *RaidGroupConfig) Validate() error {
 				r := count % 2
 				if r != 0 {
 					return errors.Errorf("Invalid device count %d for RAID type %q: Want 2^n + 1.",
-						rgc.GroupDeviceCount, rgc.Type)
+						rgc.GroupDeviceCount, rgc.RAIDType)
 				}
 				count = count / 2
 			}
@@ -139,7 +139,7 @@ func (rgc *RaidGroupConfig) Validate() error {
 				r := count % 2
 				if r != 0 {
 					return errors.Errorf("Invalid device count %d for RAID type %q: Want 2^n + 2.",
-						rgc.GroupDeviceCount, rgc.Type)
+						rgc.GroupDeviceCount, rgc.RAIDType)
 				}
 				count = count / 2
 			}
@@ -147,7 +147,7 @@ func (rgc *RaidGroupConfig) Validate() error {
 	default:
 		{
 			return errors.Errorf("Invalid RAID type %q: Supports %q, %q, %q or %q.",
-				rgc.Type, PoolRAIDTypeStripe, PoolRAIDTypeMirror, PoolRAIDTypeRAIDZ, PoolRAIDTypeRAIDZ2)
+				rgc.RAIDType, PoolRAIDTypeStripe, PoolRAIDTypeMirror, PoolRAIDTypeRAIDZ, PoolRAIDTypeRAIDZ2)
 		}
 	}
 	return nil

--- a/types/raidgroupconfig.go
+++ b/types/raidgroupconfig.go
@@ -23,7 +23,7 @@ import "github.com/pkg/errors"
 type RaidGroupConfig struct {
 	// Type is the raid group type
 	// Supported values are : stripe, mirror, raidz and raidz2
-	Type PoolRAIDType `json:"type"`
+	Type PoolRAIDType `json:"raidType"`
 	// GroupDeviceCount contains device count in a raid group
 	// -- for stripe DeviceCount = 1
 	// -- for mirror DeviceCount = 2

--- a/types/raidgroupconfig_test.go
+++ b/types/raidgroupconfig_test.go
@@ -35,9 +35,9 @@ func TestGetDefaultRaidGroupConfig(t *testing.T) {
 		mock := mock
 		t.Run(name, func(t *testing.T) {
 			got := GetDefaultRaidGroupConfig()
-			if got.Type != mock.expectedType {
+			if got.RAIDType != mock.expectedType {
 				t.Fatalf("expected type %s but got %s",
-					mock.expectedType, got.Type)
+					mock.expectedType, got.RAIDType)
 			}
 			if got.GroupDeviceCount != mock.expectedGroupDeviceCount {
 				t.Fatalf("expected device count %d but got %d",
@@ -55,14 +55,14 @@ func TestPopulateDefaultGroupDeviceCount(t *testing.T) {
 	}{
 		"stripe pool and device count not set": {
 			src: &RaidGroupConfig{
-				Type: PoolRAIDTypeStripe,
+				RAIDType: PoolRAIDTypeStripe,
 			},
 			expectedGroupDeviceCount: RAIDTypeToDefaultMinDiskCount[PoolRAIDTypeStripe],
 			isErr:                    false,
 		},
 		"stripe pool and device count set": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeStripe,
+				RAIDType:         PoolRAIDTypeStripe,
 				GroupDeviceCount: 7,
 			},
 			expectedGroupDeviceCount: 7,
@@ -70,14 +70,14 @@ func TestPopulateDefaultGroupDeviceCount(t *testing.T) {
 		},
 		"mirror pool and device count not set": {
 			src: &RaidGroupConfig{
-				Type: PoolRAIDTypeMirror,
+				RAIDType: PoolRAIDTypeMirror,
 			},
 			expectedGroupDeviceCount: RAIDTypeToDefaultMinDiskCount[PoolRAIDTypeMirror],
 			isErr:                    false,
 		},
 		"mirror pool and device count set": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeMirror,
+				RAIDType:         PoolRAIDTypeMirror,
 				GroupDeviceCount: 7,
 			},
 			expectedGroupDeviceCount: 7,
@@ -85,14 +85,14 @@ func TestPopulateDefaultGroupDeviceCount(t *testing.T) {
 		},
 		"raidz pool and device count not set": {
 			src: &RaidGroupConfig{
-				Type: PoolRAIDTypeRAIDZ,
+				RAIDType: PoolRAIDTypeRAIDZ,
 			},
 			expectedGroupDeviceCount: RAIDTypeToDefaultMinDiskCount[PoolRAIDTypeRAIDZ],
 			isErr:                    false,
 		},
 		"raidz pool and device count set": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeRAIDZ,
+				RAIDType:         PoolRAIDTypeRAIDZ,
 				GroupDeviceCount: 7,
 			},
 			expectedGroupDeviceCount: 7,
@@ -100,14 +100,14 @@ func TestPopulateDefaultGroupDeviceCount(t *testing.T) {
 		},
 		"raidz2 pool and device count not set": {
 			src: &RaidGroupConfig{
-				Type: PoolRAIDTypeRAIDZ2,
+				RAIDType: PoolRAIDTypeRAIDZ2,
 			},
 			expectedGroupDeviceCount: RAIDTypeToDefaultMinDiskCount[PoolRAIDTypeRAIDZ2],
 			isErr:                    false,
 		},
 		"raidz2 pool and device count set": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeRAIDZ2,
+				RAIDType:         PoolRAIDTypeRAIDZ2,
 				GroupDeviceCount: 7,
 			},
 			expectedGroupDeviceCount: 7,
@@ -115,13 +115,13 @@ func TestPopulateDefaultGroupDeviceCount(t *testing.T) {
 		},
 		"invalid raid type and device count is not set": {
 			src: &RaidGroupConfig{
-				Type: PoolRAIDType(""),
+				RAIDType: PoolRAIDType(""),
 			},
 			isErr: true,
 		},
 		"invalid raid type and device count is set": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDType(""),
+				RAIDType:         PoolRAIDType(""),
 				GroupDeviceCount: 1,
 			},
 			expectedGroupDeviceCount: 1,
@@ -155,28 +155,28 @@ func TestGetDataDeviceCount(t *testing.T) {
 	}{
 		"stripe pool": {
 			src: &RaidGroupConfig{
-				Type: PoolRAIDTypeStripe,
+				RAIDType: PoolRAIDTypeStripe,
 			},
 			devicecount:     []int64{1, 2, 3, 4, 5, 6, 7, 8, 9},
 			datadevicecount: []int64{1, 2, 3, 4, 5, 6, 7, 8, 9},
 		},
 		"mirror pool": {
 			src: &RaidGroupConfig{
-				Type: PoolRAIDTypeMirror,
+				RAIDType: PoolRAIDTypeMirror,
 			},
 			devicecount:     []int64{2, 4, 6, 8, 10, 12, 14, 16, 18},
 			datadevicecount: []int64{1, 2, 3, 4, 5, 6, 7, 8, 9},
 		},
 		"raidz pool": {
 			src: &RaidGroupConfig{
-				Type: PoolRAIDTypeRAIDZ,
+				RAIDType: PoolRAIDTypeRAIDZ,
 			},
 			devicecount:     []int64{3, 5, 9, 17, 33, 65},
 			datadevicecount: []int64{2, 4, 8, 16, 32, 64},
 		},
 		"raidz2 pool": {
 			src: &RaidGroupConfig{
-				Type: PoolRAIDTypeRAIDZ2,
+				RAIDType: PoolRAIDTypeRAIDZ2,
 			},
 			devicecount:     []int64{4, 6, 10, 18, 34, 66},
 			datadevicecount: []int64{2, 4, 8, 16, 32, 64},
@@ -207,112 +207,112 @@ func TestValidate(t *testing.T) {
 	}{
 		"stripe pool and device count is -ve": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeStripe,
+				RAIDType:         PoolRAIDTypeStripe,
 				GroupDeviceCount: -3,
 			},
 			isErr: true,
 		},
 		"mirror pool and device count is -ve": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeMirror,
+				RAIDType:         PoolRAIDTypeMirror,
 				GroupDeviceCount: -3,
 			},
 			isErr: true,
 		},
 		"raidz pool and device count is -ve": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeRAIDZ,
+				RAIDType:         PoolRAIDTypeRAIDZ,
 				GroupDeviceCount: -3,
 			},
 			isErr: true,
 		},
 		"raidz2 pool and device count is -ve": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeRAIDZ2,
+				RAIDType:         PoolRAIDTypeRAIDZ2,
 				GroupDeviceCount: -3,
 			},
 			isErr: true,
 		},
 		"stripe pool and device count is less than min count": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeStripe,
+				RAIDType:         PoolRAIDTypeStripe,
 				GroupDeviceCount: 0,
 			},
 			isErr: true,
 		},
 		"stripe pool and valid device count": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeStripe,
+				RAIDType:         PoolRAIDTypeStripe,
 				GroupDeviceCount: 2,
 			},
 			isErr: false,
 		},
 		"mirror pool and invalid device count": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeMirror,
+				RAIDType:         PoolRAIDTypeMirror,
 				GroupDeviceCount: 3,
 			},
 			isErr: true,
 		},
 		"mirror pool and valid device count": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeMirror,
+				RAIDType:         PoolRAIDTypeMirror,
 				GroupDeviceCount: 2,
 			},
 			isErr: false,
 		},
 		"mirror pool and device count is less than min count": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeMirror,
+				RAIDType:         PoolRAIDTypeMirror,
 				GroupDeviceCount: 0,
 			},
 			isErr: true,
 		},
 		"raidz pool and invalid device count": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeRAIDZ,
+				RAIDType:         PoolRAIDTypeRAIDZ,
 				GroupDeviceCount: 4,
 			},
 			isErr: true,
 		},
 		"raidz pool and device count is less than min count": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeRAIDZ,
+				RAIDType:         PoolRAIDTypeRAIDZ,
 				GroupDeviceCount: 1,
 			},
 			isErr: true,
 		},
 		"raidz pool and valid device count": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeRAIDZ,
+				RAIDType:         PoolRAIDTypeRAIDZ,
 				GroupDeviceCount: 3,
 			},
 			isErr: false,
 		},
 		"raidz2 pool and invalid device count": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeRAIDZ2,
+				RAIDType:         PoolRAIDTypeRAIDZ2,
 				GroupDeviceCount: 5,
 			},
 			isErr: true,
 		},
 		"raidz2 pool and valid device count": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeRAIDZ2,
+				RAIDType:         PoolRAIDTypeRAIDZ2,
 				GroupDeviceCount: 6,
 			},
 			isErr: false,
 		},
 		"raidz2 pool and device count is less than min count": {
 			src: &RaidGroupConfig{
-				Type:             PoolRAIDTypeRAIDZ2,
+				RAIDType:         PoolRAIDTypeRAIDZ2,
 				GroupDeviceCount: 2,
 			},
 			isErr: true,
 		},
 		"invalid raid type and device count is not set": {
 			src: &RaidGroupConfig{
-				Type: PoolRAIDType(""),
+				RAIDType: PoolRAIDType(""),
 			},
 			isErr: true,
 		},


### PR DESCRIPTION
- Change the name of raidType from 'type' to 'raidType' in structure.
- Update the device recommendation logic. It was not returning the prevDataDevices if the requestedCapacity is equal to the capacity.