### PR TITLE
feat(localdevice): delete CStorPoolCluster when CStorClusterConfig is deleted

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,6 +49,7 @@ func main() {
 	generic.AddToInlineRegistry("sync/blockdevice", blockdevice.Sync)
 	generic.AddToInlineRegistry("sync/cstorpoolcluster", cstorpoolcluster.Sync)
 	generic.AddToInlineRegistry("sync/localdevice", localdevice.Sync)
+	generic.AddToInlineRegistry("finalize/localdevice", localdevice.Finalize)
 
 	start.Start()
 }

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -4,11 +4,12 @@ metadata:
   name: sync-localdevice
   namespace: cspauto
 spec:
-  updateAny: true
   watch:
     apiVersion: dao.mayadata.io/v1alpha1
     resource: cstorclusterconfigs
   attachments:
+  - apiVersion: openebs.io/v1alpha1
+    resource: blockdevices
   - apiVersion: openebs.io/v1alpha1
     resource: cstorpoolclusters
     updateStrategy:
@@ -21,11 +22,41 @@ spec:
           dao.mayadata.io/cstorclusterconfig-localdisk: "true"
         matchReferenceExpressions:
         - key: metadata.annotations.dao\.mayadata\.io/cstorclusterconfig-uid
-          refKey: metadata.uid # match ann key's value against watch UID
+          refKey: metadata.uid # match this ann value against watch UID
   hooks:
+    # controller gets triggered through this hook when 
+    # CStorClusterConfig gets created or modified
     sync:
       inline:
         funcName: sync/localdevice
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  name: finalize-localdevice
+  namespace: cspauto
+spec:
+  watch:
+    apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorclusterconfigs
+  attachments:
+  - apiVersion: openebs.io/v1alpha1
+    resource: cstorpoolclusters
+    advancedSelector:
+      selectorTerms:
+      # select CStorPoolCluster resources if its annotation
+      # has both the following
+      - matchAnnotations:
+          dao.mayadata.io/cstorclusterconfig-localdisk: "true"
+        matchReferenceExpressions:
+        - key: metadata.annotations.dao\.mayadata\.io/cstorclusterconfig-uid
+          refKey: metadata.uid # match this ann value against watch UID
+  hooks:
+    # controller gets triggered through this hook only when 
+    # CStorClusterConfig (i.e. watch) is deleted
+    finalize:
+      inline:
+        funcName: finalize/localdevice
 ---
 apiVersion: metac.openebs.io/v1alpha1
 kind: GenericController

--- a/controller/localdevice/finalizer.go
+++ b/controller/localdevice/finalizer.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localdevice
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"openebs.io/metac/controller/generic"
+
+	ccc "mayadata.io/cstorpoolauto/util/cstorclusterconfig"
+	metacutil "mayadata.io/cstorpoolauto/util/metac"
+)
+
+type finalizer struct {
+	request  *generic.SyncHookRequest
+	response *generic.SyncHookResponse
+
+	isDiskLocal bool
+	fatal       error
+	err         error
+	warns       []string
+}
+
+func (f *finalizer) validateArgs() {
+	// validation failure of request &/ response is a fatal error
+	f.fatal = metacutil.ValidateGenericControllerArgs(f.request, f.response)
+}
+
+func (f *finalizer) skipIfNotLocalDisk() {
+	f.isDiskLocal, f.err =
+		ccc.NewHelper(f.request.Watch).IsLocalBlockDiskConfig()
+	if f.err != nil {
+		return
+	}
+	if !f.isDiskLocal {
+		var msg = fmt.Sprintf(
+			"Will skip LocalDevice finalize: DiskConfig is not local: Watch %q - %q / %q",
+			f.request.Watch.GetKind(),
+			f.request.Watch.GetNamespace(),
+			f.request.Watch.GetName(),
+		)
+		glog.V(3).Infof(msg)
+		// we want to skip reconciling this since this CstorClusterConfig
+		// is not meant for local devices
+		f.response.SkipReconcile = true
+	}
+}
+
+func (f *finalizer) logFinalizeStart() {
+	glog.V(3).Infof(
+		"Started LocalDevice finalize: Watch %q - %q / %q",
+		f.request.Watch.GetKind(),
+		f.request.Watch.GetNamespace(),
+		f.request.Watch.GetName(),
+	)
+}
+
+func (f *finalizer) markFinalizedIfNoAttachments() {
+	// Finalize is completed if there are no attachments in request
+	//
+	// NOTE:
+	// 	It is expected to have CStorPoolCluster as attachments
+	// during the process of finalizing
+	if f.request.Attachments == nil || f.request.Attachments.IsEmpty() {
+		var msg = fmt.Sprintf(
+			"Finalize LocalDevice completed: Watch %q - %q / %q",
+			f.request.Watch.GetKind(),
+			f.request.Watch.GetNamespace(),
+			f.request.Watch.GetName(),
+		)
+		glog.V(3).Infof(msg)
+		// setting finalized to true will indicate metac to remove
+		// its annotations from the watch i.e. CStorClusterConfig
+		f.response.Finalized = true
+	}
+}
+
+func (f *finalizer) logFinalizeFinish() {
+	glog.V(2).Infof(
+		"Completed LocalDevice finalize: Watch %q - %q / %q: %s",
+		f.request.Watch.GetKind(),
+		f.request.Watch.GetNamespace(),
+		f.request.Watch.GetName(),
+		metacutil.GetDetailsFromResponse(f.response),
+	)
+}
+
+// handleError logs the error if any
+func (f *finalizer) handleError() {
+	if f.err == nil {
+		// nothing to do if there was no error
+		return
+	}
+	// log this error with context
+	glog.Errorf(
+		"Failed to finalize LocalDevice: Watch %q - %q / %q: %+v",
+		f.request.Watch.GetKind(),
+		f.request.Watch.GetNamespace(),
+		f.request.Watch.GetName(),
+		f.err,
+	)
+	// stop further reconciliation at metac since there was an error
+	f.response.SkipReconcile = true
+}
+
+func (f *finalizer) finalize() error {
+	fns := []func(){
+		f.validateArgs,
+		f.skipIfNotLocalDisk,
+		f.logFinalizeStart,
+		f.markFinalizedIfNoAttachments,
+		f.logFinalizeFinish,
+	}
+	for _, fn := range fns {
+		fn()
+		// post operation checks
+		if f.fatal != nil {
+			// this panics
+			return f.fatal
+		}
+		if f.err != nil {
+			// this logs the error thus avoiding panic in the
+			// controller
+			f.handleError()
+		}
+		if f.response.SkipReconcile {
+			return nil
+		}
+	}
+	return nil
+}
+
+// Finalize implements the idempotent logic to finalize
+// CStorClusterConfig. This gets triggered only when
+// CStorClusterConfig is being deleted.
+//
+// NOTE:
+// 	Finalize hook automatically sets a finalizer against the watch.
+// This finalizer us removed when hookresponse's Finalized field
+// is set to true.
+//
+// NOTE:
+// 	SyncHookRequest is the payload received as part of finalize
+// request. Similarly, SyncHookResponse is the payload sent as a
+// response as part of finalize request.
+//
+// NOTE:
+//	SyncHookRequest uses CStorClusterConfig as the watched resource.
+// SyncHookResponse uses CStorPoolCluster to form the desired state
+// w.r.t the watched resource. We don't return CStorPoolCluster
+// in the response since that would imply deleting the same in the
+// cluster.
+//
+// NOTE:
+//	Returning error will panic this process. We would rather want this
+// controller to run continuously. Hence, the errors are handled.
+func Finalize(request *generic.SyncHookRequest, response *generic.SyncHookResponse) error {
+	f := &finalizer{
+		request:  request,
+		response: response,
+	}
+	return f.finalize()
+}

--- a/controller/localdevice/finalizer_test.go
+++ b/controller/localdevice/finalizer_test.go
@@ -1,0 +1,521 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localdevice
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mayadata.io/cstorpoolauto/types"
+	"openebs.io/metac/controller/common"
+	"openebs.io/metac/controller/generic"
+)
+
+func TestValidateArgs(t *testing.T) {
+	var tests = map[string]struct {
+		request  *generic.SyncHookRequest
+		response *generic.SyncHookResponse
+		isErr    bool
+	}{
+		"nil everything": {
+			isErr: true,
+		},
+		"not nil request & nil watch & nil response": {
+			request: &generic.SyncHookRequest{},
+			isErr:   true,
+		},
+		"not nil request & not nil watch & nil response": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+			},
+			isErr: true,
+		},
+		"not nil everything": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+			},
+			response: &generic.SyncHookResponse{},
+			isErr:    false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			f := &finalizer{
+				request:  mock.request,
+				response: mock.response,
+			}
+			f.validateArgs()
+			if mock.isErr && f.fatal == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && f.fatal != nil {
+				t.Fatalf("Expected no error got [%+v]", f.fatal)
+			}
+		})
+	}
+}
+
+func TestFinalizerSkipIfNotLocalDisk(t *testing.T) {
+	var tests = map[string]struct {
+		finalizer *finalizer
+		isSkip    bool
+		isErr     bool
+	}{
+		"empty watch": {
+			finalizer: &finalizer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isErr: true,
+		},
+		"invalid watch kind": {
+			finalizer: &finalizer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": "Junk",
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isErr: true,
+		},
+		"valid watch kind && empty specs": {
+			finalizer: &finalizer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && empty diskconfig": {
+			finalizer: &finalizer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && nil diskconfig.local": {
+			finalizer: &finalizer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": nil,
+								},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && nil diskconfig.local.blockDeviceSelector": {
+			finalizer: &finalizer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": nil,
+									},
+								},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && nil diskconfig.local.blockDeviceSelector.selectorTerms": {
+			finalizer: &finalizer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": map[string]interface{}{
+											"selectorTerms": []interface{}(nil),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && 0 diskconfig.local.blockDeviceSelector.selectorTerms": {
+			finalizer: &finalizer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": map[string]interface{}{
+											"selectorTerms": []interface{}{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: true,
+			isErr:  false,
+		},
+		"valid watch kind && 1 empty diskconfig.local.blockDeviceSelector.selectorTerms": {
+			finalizer: &finalizer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": string(types.KindCStorClusterConfig),
+							"spec": map[string]interface{}{
+								"diskConfig": map[string]interface{}{
+									"local": map[string]interface{}{
+										"blockDeviceSelector": map[string]interface{}{
+											"selectorTerms": []interface{}{
+												map[string]interface{}{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+			},
+			isSkip: false,
+			isErr:  false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			mock.finalizer.skipIfNotLocalDisk()
+			if mock.isErr && mock.finalizer.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && mock.finalizer.err != nil {
+				t.Fatalf("Expected no error got [%+v]", mock.finalizer.err)
+			}
+			if mock.isSkip != mock.finalizer.response.SkipReconcile {
+				t.Fatalf(
+					"Expected skip %t got %t",
+					mock.isSkip, mock.finalizer.response.SkipReconcile,
+				)
+			}
+		})
+	}
+}
+
+func TestMarkFinalizedIfEmptyAttachments(t *testing.T) {
+	var tests = map[string]struct {
+		request     *generic.SyncHookRequest
+		isFinalized bool
+	}{
+		"nil attachments": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+			},
+			isFinalized: true,
+		},
+		"no attachment registry": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+				Attachments: common.AnyUnstructRegistry{},
+			},
+			isFinalized: true,
+		},
+		"nil attachment registry": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+				Attachments: common.AnyUnstructRegistry(
+					map[string]map[string]*unstructured.Unstructured{},
+				),
+			},
+			isFinalized: true,
+		},
+		"one nil attachment in registry": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+				Attachments: common.AnyUnstructRegistry(
+					map[string]map[string]*unstructured.Unstructured{
+						"apivers/kind": map[string]*unstructured.Unstructured{
+							"ns/name": nil,
+						},
+					},
+				),
+			},
+			isFinalized: true,
+		},
+		"one not nil attachment in registry": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+				Attachments: common.AnyUnstructRegistry(
+					map[string]map[string]*unstructured.Unstructured{
+						"apivers/kind": map[string]*unstructured.Unstructured{
+							"ns/name": &unstructured.Unstructured{
+								Object: map[string]interface{}{},
+							},
+						},
+					},
+				),
+			},
+			isFinalized: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			f := &finalizer{
+				request:  mock.request,
+				response: &generic.SyncHookResponse{},
+			}
+			f.markFinalizedIfNoAttachments()
+			if mock.isFinalized != f.response.Finalized {
+				t.Fatalf(
+					"Expected finalized %t got %t",
+					mock.isFinalized,
+					f.response.Finalized,
+				)
+			}
+		})
+	}
+}
+
+func TestHandleError(t *testing.T) {
+	var tests = map[string]struct {
+		err             error
+		isSkipReconcile bool
+	}{
+		"nil error": {
+			err:             nil,
+			isSkipReconcile: false,
+		},
+		"not nil error": {
+			err:             errors.Errorf("Error"),
+			isSkipReconcile: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			f := &finalizer{
+				request: &generic.SyncHookRequest{
+					Watch: &unstructured.Unstructured{
+						Object: map[string]interface{}{},
+					},
+				},
+				response: &generic.SyncHookResponse{},
+				err:      mock.err,
+			}
+			f.handleError()
+			if mock.isSkipReconcile != f.response.SkipReconcile {
+				t.Fatalf(
+					"Expected skip reconcile %t got %t",
+					mock.isSkipReconcile,
+					f.response.SkipReconcile,
+				)
+			}
+		})
+	}
+}
+
+func TestFinalize(t *testing.T) {
+	var tests = map[string]struct {
+		request         *generic.SyncHookRequest
+		response        *generic.SyncHookResponse
+		isErr           bool
+		isSkipReconcile bool
+		isFinalized     bool
+	}{
+		"invalid CStorClusterConfig": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{},
+				},
+			},
+			response:        &generic.SyncHookResponse{},
+			isErr:           true,
+			isSkipReconcile: true,
+		},
+		"CStorClusterConfig without local device config": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"spec": map[string]interface{}{
+							"diskConfig": map[string]interface{}{
+								"local": nil,
+							},
+						},
+					},
+				},
+			},
+			response:        &generic.SyncHookResponse{},
+			isSkipReconcile: true,
+		},
+		"CStorClusterConfig with local device config & selector terms": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"spec": map[string]interface{}{
+							"diskConfig": map[string]interface{}{
+								"local": map[string]interface{}{
+									"blockDeviceSelector": map[string]interface{}{
+										"selectorTerms": []interface{}{
+											map[string]interface{}{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			response:    &generic.SyncHookResponse{},
+			isFinalized: true,
+		},
+		"CStorClusterConfig + local device config & selector terms + attachment": {
+			request: &generic.SyncHookRequest{
+				Watch: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": string(types.KindCStorClusterConfig),
+						"spec": map[string]interface{}{
+							"diskConfig": map[string]interface{}{
+								"local": map[string]interface{}{
+									"blockDeviceSelector": map[string]interface{}{
+										"selectorTerms": []interface{}{
+											map[string]interface{}{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Attachments: common.MakeAnyUnstructRegistry(
+					[]*unstructured.Unstructured{
+						&unstructured.Unstructured{
+							Object: map[string]interface{}{
+								"kind":       "CStorPoolCluster",
+								"apiVersion": "openebs.io/v1alpha1",
+								"metadata": map[string]interface{}{
+									"name": "test",
+								},
+							},
+						},
+					},
+				),
+			},
+			response:    &generic.SyncHookResponse{},
+			isFinalized: false,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			f := &finalizer{
+				request:  mock.request,
+				response: mock.response,
+			}
+			f.finalize()
+			if mock.isErr && f.err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !mock.isErr && f.err != nil {
+				t.Fatalf("Expected no error got [%+v]", f.err)
+			}
+			if mock.isSkipReconcile != f.response.SkipReconcile {
+				t.Fatalf(
+					"Expected skip reconcile %t got %t",
+					mock.isSkipReconcile,
+					f.response.SkipReconcile,
+				)
+			}
+			if mock.isFinalized != f.response.Finalized {
+				t.Fatalf(
+					"Expected finalized %t got %t",
+					mock.isFinalized,
+					f.response.Finalized,
+				)
+			}
+		})
+	}
+}

--- a/controller/localdevice/reconciler.go
+++ b/controller/localdevice/reconciler.go
@@ -74,7 +74,7 @@ func (s *syncer) skipIfEmptyAttachments() {
 	// Nothing needs to be done if there are no attachments in request
 	//
 	// NOTE:
-	// 	It is expected to have BlockDevices as attachments
+	// 	It is expected to have at-least BlockDevices as attachments
 	if s.request.Attachments == nil || s.request.Attachments.IsEmpty() {
 		var msg = fmt.Sprintf(
 			"Will skip LocalDevice sync: Nil attachments: Watch %q - %q / %q",

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module mayadata.io/cstorpoolauto
 go 1.13
 
 require (
+	github.com/coreos/etcd v3.3.15+incompatible // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/go-cmp v0.3.0
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
This commit implements the finalize logic against `CStorClusterConfig` objects. This is particular to those `CStorClusterConfig` instances that has local device selectors.

_NOTE: finalize is opposite of sync logic_
_NOTE: finalize is triggered only when watch object is deleted whereas sync logic is triggered only when watch object is created or updated or after some time interval_

closes #109

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>