### PR TITLE
feat(local): add support for v1 cspc creation

### DIFF
--- a/common/cstorpoolcluster/builder.go
+++ b/common/cstorpoolcluster/builder.go
@@ -223,7 +223,7 @@ func (b *Builder) buildDesiredRAIDGroupsByHostName(nodeName string) []interface{
 		var raidGroupList []interface{}
 		var raidGroup []string
 
-		// Stripe pool contains only one raid group.
+		// Stripe pool implies only one raid group that contains all the disks
 		if b.DesiredRAIDType == types.PoolRAIDTypeStripe {
 			raidGroupList = append(raidGroupList, buildSingleRAIDGroup(deviceNames))
 			return raidGroupList

--- a/common/cstorpoolcluster/builder.go
+++ b/common/cstorpoolcluster/builder.go
@@ -223,6 +223,12 @@ func (b *Builder) buildDesiredRAIDGroupsByHostName(nodeName string) []interface{
 		var raidGroupList []interface{}
 		var raidGroup []string
 
+		// Stripe pool contains only one raid group.
+		if b.DesiredRAIDType == types.PoolRAIDTypeStripe {
+			raidGroupList = append(raidGroupList, buildSingleRAIDGroup(deviceNames))
+			return raidGroupList
+		}
+
 		diskCountByRAIDType :=
 			int(types.RAIDTypeToDefaultMinDiskCount[b.DesiredRAIDType])
 		for idx, deviceName := range deviceNames {
@@ -235,7 +241,6 @@ func (b *Builder) buildDesiredRAIDGroupsByHostName(nodeName string) []interface{
 			// 	- Mirror has 2 disks per raid group
 			//	- RAIDZ has 3 disks per raid group
 			//  - RAIDZ2 has 6 disks per raid group
-			//  - Stripe has 1 disk per raid group
 			if (idx+1)%diskCountByRAIDType == 0 {
 				raidGroupList = append(raidGroupList, buildSingleRAIDGroup(raidGroup))
 				// reset the raidGroup to make way to build next raidGroup for this pool

--- a/common/cstorpoolcluster/builder.go
+++ b/common/cstorpoolcluster/builder.go
@@ -215,10 +215,6 @@ func (b *Builder) buildDesiredRAIDGroupsByHostName(nodeName string) []interface{
 	// local function to build a raid group
 	buildSingleRAIDGroup := func(deviceNames []string) interface{} {
 		return map[string]interface{}{
-			"type":         string(b.DesiredRAIDType),
-			"isWriteCache": false,
-			"isSpare":      false,
-			"isReadCache":  false,
 			"blockDevices": buildBlockDevices(deviceNames),
 		}
 	}
@@ -259,11 +255,11 @@ func (b *Builder) buildDesiredPoolByHostName(hostName string) interface{} {
 		"nodeSelector": map[string]interface{}{
 			"kubernetes.io/hostname": hostName,
 		},
-		"raidGroups": b.buildDesiredRAIDGroupsByHostName(hostName),
+		"dataRaidGroups": b.buildDesiredRAIDGroupsByHostName(hostName),
 		"poolConfig": map[string]interface{}{
-			"defaultRaidGroupType": string(b.DesiredRAIDType),
-			"overProvisioning":     false,
-			"compression":          "off",
+			"dataRaidGroupType": string(b.DesiredRAIDType),
+			"thickProvision":    false,
+			"compression":       "off",
 		},
 	}
 }
@@ -308,7 +304,7 @@ func (b *Builder) BuildDesiredState() (*unstructured.Unstructured, error) {
 		cspc.SetLabels(b.DesiredLabels)
 	}
 	// below is the right way to set APIVersion & Kind
-	cspc.SetAPIVersion(string(types.APIVersionOpenEBSV1Alpha1))
+	cspc.SetAPIVersion(string(types.APIVersionCStorOpenEBSV1))
 	cspc.SetKind(string(types.KindCStorPoolCluster))
 	return cspc, nil
 }

--- a/common/cstorpoolcluster/builder_test.go
+++ b/common/cstorpoolcluster/builder_test.go
@@ -107,7 +107,7 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeMirror,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1"},
+					"node-001": {"bd1"},
 				},
 			},
 			isErr: true,
@@ -118,7 +118,7 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeMirror,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2", "bd3"},
+					"node-001": {"bd1", "bd2", "bd3"},
 				},
 			},
 			isErr: true,
@@ -129,7 +129,7 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1"},
+					"node-001": {"bd1"},
 				},
 			},
 			isErr: true,
@@ -140,7 +140,7 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2", "bd3", "bd4"},
+					"node-001": {"bd1", "bd2", "bd3", "bd4"},
 				},
 			},
 			isErr: true,
@@ -151,7 +151,7 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2"},
+					"node-001": {"bd1", "bd2"},
 				},
 			},
 			isErr: true,
@@ -162,7 +162,7 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2", "bd3", "bd4", "bd5"},
+					"node-001": {"bd1", "bd2", "bd3", "bd4", "bd5"},
 				},
 			},
 			isErr: true,
@@ -173,8 +173,8 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2", "bd3", "bd4", "bd5", "bd6"},
-					"node-002": []string{"bd21", "bd22", "bd23", "bd24", "bd25"},
+					"node-001": {"bd1", "bd2", "bd3", "bd4", "bd5", "bd6"},
+					"node-002": {"bd21", "bd22", "bd23", "bd24", "bd25"},
 				},
 			},
 			isErr: true,
@@ -188,7 +188,7 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 			expect: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"apiVersion": string(types.APIVersionCStorOpenEBSV1),
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -206,13 +206,13 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeMirror,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2"},
+					"node-001": {"bd1", "bd2"},
 				},
 			},
 			expect: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"apiVersion": string(types.APIVersionCStorOpenEBSV1),
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -221,14 +221,14 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 						"pools": []interface{}{
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -238,10 +238,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 												"blockDeviceName": "bd2",
 											},
 										},
-										"type":         "mirror",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
@@ -257,16 +253,16 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeStripe,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2"}, // bd2 is new
+					"node-001": {"bd1", "bd2"}, // bd2 is new
 				},
 				HostNameToObservedDeviceNames: map[string][]string{
-					"node-001": []string{"bd1"}, // bd1 is existing
+					"node-001": {"bd1"}, // bd1 is existing
 				},
 			},
 			expect: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"apiVersion": string(types.APIVersionCStorOpenEBSV1),
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -275,24 +271,20 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 						"pools": []interface{}{
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "stripe",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "stripe",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd1",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -300,10 +292,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 												"blockDeviceName": "bd2",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
@@ -319,16 +307,16 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeStripe,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd3"}, // bd3 is new
+					"node-001": {"bd1", "bd3"}, // bd3 is new
 				},
 				HostNameToObservedDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2"}, // bd1 & bd2 are existing
+					"node-001": {"bd1", "bd2"}, // bd1 & bd2 are existing
 				},
 			},
 			expect: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"apiVersion": string(types.APIVersionCStorOpenEBSV1),
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -337,24 +325,20 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 						"pools": []interface{}{
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "stripe",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "stripe",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd1",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -362,10 +346,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 												"blockDeviceName": "bd3",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
@@ -382,18 +362,18 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				DesiredRAIDType:  types.PoolRAIDTypeStripe,
 				OrderedHostNames: []string{"node-002", "node-001"}, // reversed order
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd3"},   // bd3 is new
-					"node-002": []string{"bd21", "bd23"}, // bd23 is new
+					"node-001": {"bd1", "bd3"},   // bd3 is new
+					"node-002": {"bd21", "bd23"}, // bd23 is new
 				},
 				HostNameToObservedDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2"},   // bd1 & bd2 are existing
-					"node-002": []string{"bd21", "bd22"}, // bd21 & bd22 are existing
+					"node-001": {"bd1", "bd2"},   // bd1 & bd2 are existing
+					"node-002": {"bd21", "bd22"}, // bd21 & bd22 are existing
 				},
 			},
 			expect: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"apiVersion": string(types.APIVersionCStorOpenEBSV1),
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -402,24 +382,20 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 						"pools": []interface{}{
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "stripe",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "stripe",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-002",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd21",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -427,33 +403,25 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 												"blockDeviceName": "bd23",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "stripe",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "stripe",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd1",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -461,10 +429,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 												"blockDeviceName": "bd3",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
@@ -481,18 +445,18 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				DesiredRAIDType:  types.PoolRAIDTypeMirror,
 				OrderedHostNames: []string{"node-001", "node-002"},
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd3"},   // bd3 is new
-					"node-002": []string{"bd21", "bd23"}, // bd23 is new
+					"node-001": {"bd1", "bd3"},   // bd3 is new
+					"node-002": {"bd21", "bd23"}, // bd23 is new
 				},
 				HostNameToObservedDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2"},   // bd1 & bd2 are existing
-					"node-002": []string{"bd21", "bd22"}, // bd21 & bd22 are existing
+					"node-001": {"bd1", "bd2"},   // bd1 & bd2 are existing
+					"node-002": {"bd21", "bd22"}, // bd21 & bd22 are existing
 				},
 			},
 			expect: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"apiVersion": string(types.APIVersionCStorOpenEBSV1),
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -501,14 +465,14 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 						"pools": []interface{}{
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -518,23 +482,19 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 												"blockDeviceName": "bd3",
 											},
 										},
-										"type":         "mirror",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-002",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -544,10 +504,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 												"blockDeviceName": "bd23",
 											},
 										},
-										"type":         "mirror",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
@@ -563,10 +519,10 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeMirror,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd3", "bd4"}, // bd3 & bd4 are new
+					"node-001": {"bd1", "bd3", "bd4"}, // bd3 & bd4 are new
 				},
 				HostNameToObservedDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2"}, // bd1 & bd2 are existing
+					"node-001": {"bd1", "bd2"}, // bd1 & bd2 are existing
 				},
 			},
 			isErr: true,
@@ -577,16 +533,16 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeMirror,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd3"}, // bd2 is removed
+					"node-001": {"bd1", "bd3"}, // bd2 is removed
 				},
 				HostNameToObservedDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2", "bd3"}, // bd1, bd2 & bd3 are existing
+					"node-001": {"bd1", "bd2", "bd3"}, // bd1, bd2 & bd3 are existing
 				},
 			},
 			expect: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"apiVersion": string(types.APIVersionCStorOpenEBSV1),
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -595,14 +551,14 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 						"pools": []interface{}{
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -612,10 +568,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 												"blockDeviceName": "bd3",
 											},
 										},
-										"type":         "mirror",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
@@ -631,10 +583,10 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd3", "bd4"}, // bd3 & bd4 are new
+					"node-001": {"bd3", "bd4"}, // bd3 & bd4 are new
 				},
 				HostNameToObservedDeviceNames: map[string][]string{
-					"node-001": []string{"bd1"}, // bd1 is existing
+					"node-001": {"bd1"}, // bd1 is existing
 				},
 			},
 			isErr: true,
@@ -645,10 +597,10 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2", "bd3", "bd4"}, // bd2, bd3 & bd4 are new
+					"node-001": {"bd1", "bd2", "bd3", "bd4"}, // bd2, bd3 & bd4 are new
 				},
 				HostNameToObservedDeviceNames: map[string][]string{
-					"node-001": []string{"bd1"}, // bd1 is existing
+					"node-001": {"bd1"}, // bd1 is existing
 				},
 			},
 			isErr: true,
@@ -659,10 +611,10 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeRAIDZ2,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2", "bd3", "bd4"}, // bd2, bd3 & bd4 are new
+					"node-001": {"bd1", "bd2", "bd3", "bd4"}, // bd2, bd3 & bd4 are new
 				},
 				HostNameToObservedDeviceNames: map[string][]string{
-					"node-001": []string{"bd1"}, // bd1 is existing
+					"node-001": {"bd1"}, // bd1 is existing
 				},
 			},
 			isErr: true,
@@ -673,16 +625,16 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				Namespace:       "test",
 				DesiredRAIDType: types.PoolRAIDTypeRAIDZ2,
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2", "bd3", "bd4", "bd5", "bd6"},
+					"node-001": {"bd1", "bd2", "bd3", "bd4", "bd5", "bd6"},
 				},
 				HostNameToObservedDeviceNames: map[string][]string{
-					"node-001": []string{"bd1"}, // bd1 is existing
+					"node-001": {"bd1"}, // bd1 is existing
 				},
 			},
 			expect: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"apiVersion": string(types.APIVersionCStorOpenEBSV1),
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -691,14 +643,14 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 						"pools": []interface{}{
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "raidz2",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "raidz2",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -720,10 +672,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 												"blockDeviceName": "bd6",
 											},
 										},
-										"type":         "raidz2",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
@@ -740,18 +688,18 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 				DesiredRAIDType:  types.PoolRAIDTypeRAIDZ2,
 				OrderedHostNames: []string{"node-002", "node-001"},
 				HostNameToDesiredDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2", "bd3", "bd4", "bd5", "bd6"},
-					"node-002": []string{"bd21", "bd22", "bd23", "bd24", "bd25", "bd26"},
+					"node-001": {"bd1", "bd2", "bd3", "bd4", "bd5", "bd6"},
+					"node-002": {"bd21", "bd22", "bd23", "bd24", "bd25", "bd26"},
 				},
 				HostNameToObservedDeviceNames: map[string][]string{
-					"node-001": []string{"bd1"},  // bd1 is existing
-					"node-002": []string{"bd21"}, // bd21 is existing
+					"node-001": {"bd1"},  // bd1 is existing
+					"node-002": {"bd21"}, // bd21 is existing
 				},
 			},
 			expect: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": string(types.APIVersionOpenEBSV1Alpha1),
+					"apiVersion": string(types.APIVersionCStorOpenEBSV1),
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -760,14 +708,14 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 						"pools": []interface{}{
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "raidz2",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "raidz2",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-002",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -789,23 +737,19 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 												"blockDeviceName": "bd26",
 											},
 										},
-										"type":         "raidz2",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "raidz2",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "raidz2",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -827,10 +771,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 												"blockDeviceName": "bd6",
 											},
 										},
-										"type":         "raidz2",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},

--- a/common/cstorpoolcluster/builder_test.go
+++ b/common/cstorpoolcluster/builder_test.go
@@ -284,10 +284,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 											map[string]interface{}{
 												"blockDeviceName": "bd1",
 											},
-										},
-									},
-									map[string]interface{}{
-										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd2",
 											},
@@ -338,10 +334,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 											map[string]interface{}{
 												"blockDeviceName": "bd1",
 											},
-										},
-									},
-									map[string]interface{}{
-										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd3",
 											},
@@ -395,10 +387,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 											map[string]interface{}{
 												"blockDeviceName": "bd21",
 											},
-										},
-									},
-									map[string]interface{}{
-										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd23",
 											},
@@ -421,10 +409,6 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 											map[string]interface{}{
 												"blockDeviceName": "bd1",
 											},
-										},
-									},
-									map[string]interface{}{
-										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd3",
 											},

--- a/common/cstorpoolcluster/builder_test.go
+++ b/common/cstorpoolcluster/builder_test.go
@@ -783,3 +783,269 @@ func TestBuilderBuildDesiredState(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildDesiredRAIDGroupsByHostName(t *testing.T) {
+	var tests = map[string]struct {
+		builder *Builder
+		expect  interface{}
+	}{
+		"stripe with  n disks where n=1 disks": {
+			builder: &Builder{
+				DesiredRAIDType: types.PoolRAIDTypeStripe,
+				hostNameToFinalDeviceNames: map[string][]string{
+					"node-001": {"bd1"},
+				},
+			},
+			expect: []interface{}{
+				map[string]interface{}{
+					"blockDevices": []interface{}{
+						map[string]interface{}{
+							"blockDeviceName": "bd1",
+						},
+					},
+				},
+			},
+		},
+		"stripe with  n disks where n>1 disks": {
+			builder: &Builder{
+				DesiredRAIDType: types.PoolRAIDTypeStripe,
+				hostNameToFinalDeviceNames: map[string][]string{
+					"node-001": {"bd1", "bd2", "bd3"},
+				},
+			},
+			expect: []interface{}{
+				map[string]interface{}{
+					"blockDevices": []interface{}{
+						map[string]interface{}{
+							"blockDeviceName": "bd1",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd2",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd3",
+						},
+					},
+				},
+			},
+		},
+		"mirror with  2n disks where n=1 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeMirror,
+				hostNameToFinalDeviceNames: map[string][]string{
+					"node-001": {"bd1", "bd2"},
+				},
+			},
+			expect: []interface{}{
+				map[string]interface{}{
+					"blockDevices": []interface{}{
+						map[string]interface{}{
+							"blockDeviceName": "bd1",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd2",
+						},
+					},
+				},
+			},
+		},
+		"mirror with  2n disks where n>1 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeMirror,
+				hostNameToFinalDeviceNames: map[string][]string{
+					"node-001": {"bd1", "bd2", "bd3", "bd4"},
+				},
+			},
+			expect: []interface{}{
+				map[string]interface{}{
+					"blockDevices": []interface{}{
+						map[string]interface{}{
+							"blockDeviceName": "bd1",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd2",
+						},
+					},
+				},
+				map[string]interface{}{
+					"blockDevices": []interface{}{
+						map[string]interface{}{
+							"blockDeviceName": "bd3",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd4",
+						},
+					},
+				},
+			},
+		},
+		"raidz with 2n+1 disks where n=1 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
+				hostNameToFinalDeviceNames: map[string][]string{
+					"node-001": {"bd1", "bd2", "bd3"},
+				},
+			},
+			expect: []interface{}{
+				map[string]interface{}{
+					"blockDevices": []interface{}{
+						map[string]interface{}{
+							"blockDeviceName": "bd1",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd2",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd3",
+						},
+					},
+				},
+			},
+		},
+		"raidz with 2n+1 disks where n>1 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ,
+				hostNameToFinalDeviceNames: map[string][]string{
+					"node-001": {"bd1", "bd2", "bd3", "bd4", "bd5", "bd6"},
+				},
+			},
+			expect: []interface{}{
+				map[string]interface{}{
+					"blockDevices": []interface{}{
+						map[string]interface{}{
+							"blockDeviceName": "bd1",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd2",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd3",
+						},
+					},
+				},
+				map[string]interface{}{
+					"blockDevices": []interface{}{
+						map[string]interface{}{
+							"blockDeviceName": "bd4",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd5",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd6",
+						},
+					},
+				},
+			},
+		},
+		"raidz2 with 2n+2 disks where n=2 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ2,
+				hostNameToFinalDeviceNames: map[string][]string{
+					"node-001": {"bd1", "bd2", "bd3", "bd4", "bd5", "bd6"},
+				},
+			},
+			expect: []interface{}{
+				map[string]interface{}{
+					"blockDevices": []interface{}{
+						map[string]interface{}{
+							"blockDeviceName": "bd1",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd2",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd3",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd4",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd5",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd6",
+						},
+					},
+				},
+			},
+		},
+		"raidz2 with 2n+2 disks where n>2 disks": {
+			builder: &Builder{
+				Name:            "test",
+				Namespace:       "test",
+				DesiredRAIDType: types.PoolRAIDTypeRAIDZ2,
+				hostNameToFinalDeviceNames: map[string][]string{
+					"node-001": {"bd1", "bd2", "bd3", "bd4", "bd5", "bd6", "bd7", "bd8", "bd9", "bd10", "bd11", "bd12"},
+				},
+			},
+			expect: []interface{}{
+				map[string]interface{}{
+					"blockDevices": []interface{}{
+						map[string]interface{}{
+							"blockDeviceName": "bd1",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd2",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd3",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd4",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd5",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd6",
+						},
+					},
+				},
+				map[string]interface{}{
+					"blockDevices": []interface{}{
+						map[string]interface{}{
+							"blockDeviceName": "bd7",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd8",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd9",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd10",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd11",
+						},
+						map[string]interface{}{
+							"blockDeviceName": "bd12",
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			b := mock.builder
+			got := b.buildDesiredRAIDGroupsByHostName("node-001")
+			if !reflect.DeepEqual(got, mock.expect) {
+				t.Fatalf("Expected no diff got\n%s", cmp.Diff(got, mock.expect))
+			}
+		})
+	}
+}

--- a/common/cstorpoolcluster/helper.go
+++ b/common/cstorpoolcluster/helper.go
@@ -143,12 +143,12 @@ func (h *Helper) GroupBlockDeviceNamesByHostName() (map[string][]string, error) 
 	}
 	// local function to get blockdevices per pool
 	getBlockDevicesPerPool := func(obj *unstructured.Unstructured) error {
-		raidGroups, err := unstruct.GetSliceOrError(obj, "spec", "raidGroups")
+		dataRaidGroups, err := unstruct.GetSliceOrError(obj, "spec", "dataRaidGroups")
 		if err != nil {
 			return err
 		}
 		// iterate through each raidgroup
-		return unstruct.SliceIterator(raidGroups).ForEach(getBlockDevicesPerRAIDGroup)
+		return unstruct.SliceIterator(dataRaidGroups).ForEach(getBlockDevicesPerRAIDGroup)
 	}
 	// logic starts here
 	pools, err := unstruct.GetSliceOrError(h.CStorPoolCluster, "spec", "pools")

--- a/common/cstorpoolcluster/helper_test.go
+++ b/common/cstorpoolcluster/helper_test.go
@@ -92,15 +92,15 @@ func TestHelperGetAllHostNames(t *testing.T) {
 							// pool on node-001
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								// 3 raidGroups per pool
-								"raidGroups": []interface{}{
+								// 3 dataRaidGroups per pool
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -110,7 +110,6 @@ func TestHelperGetAllHostNames(t *testing.T) {
 												"blockDeviceName": "bd12",
 											},
 										},
-										"type": "mirror",
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -121,7 +120,6 @@ func TestHelperGetAllHostNames(t *testing.T) {
 												"blockDeviceName": "bd14",
 											},
 										},
-										"type": "mirror",
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -132,22 +130,21 @@ func TestHelperGetAllHostNames(t *testing.T) {
 												"blockDeviceName": "bd16",
 											},
 										},
-										"type": "mirror",
 									},
 								},
 							},
 							// pool on node-002
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-002",
 								},
-								// 3 raidGroups per pool
-								"raidGroups": []interface{}{
+								// 3 dataRaidGroups per pool
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -157,7 +154,6 @@ func TestHelperGetAllHostNames(t *testing.T) {
 												"blockDeviceName": "bd22",
 											},
 										},
-										"type": "mirror",
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -168,7 +164,6 @@ func TestHelperGetAllHostNames(t *testing.T) {
 												"blockDeviceName": "bd24",
 											},
 										},
-										"type": "mirror",
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -179,7 +174,6 @@ func TestHelperGetAllHostNames(t *testing.T) {
 												"blockDeviceName": "bd26",
 											},
 										},
-										"type": "mirror",
 									},
 								},
 							},
@@ -202,7 +196,7 @@ func TestHelperGetAllHostNames(t *testing.T) {
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{},
+								"dataRaidGroups": []interface{}{},
 							},
 						},
 					},
@@ -295,15 +289,15 @@ func TestHelperGroupBlockDeviceNamesByHostName(t *testing.T) {
 							// pool on node-001
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								// 3 raidGroups per pool
-								"raidGroups": []interface{}{
+								// 3 dataRaidGroups per pool
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -313,7 +307,6 @@ func TestHelperGroupBlockDeviceNamesByHostName(t *testing.T) {
 												"blockDeviceName": "bd12",
 											},
 										},
-										"type": "mirror",
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -324,7 +317,6 @@ func TestHelperGroupBlockDeviceNamesByHostName(t *testing.T) {
 												"blockDeviceName": "bd14",
 											},
 										},
-										"type": "mirror",
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -335,22 +327,21 @@ func TestHelperGroupBlockDeviceNamesByHostName(t *testing.T) {
 												"blockDeviceName": "bd16",
 											},
 										},
-										"type": "mirror",
 									},
 								},
 							},
 							// pool on node-002
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-002",
 								},
-								// 2 raidGroups per pool
-								"raidGroups": []interface{}{
+								// 2 dataRaidGroups per pool
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -360,7 +351,6 @@ func TestHelperGroupBlockDeviceNamesByHostName(t *testing.T) {
 												"blockDeviceName": "bd22",
 											},
 										},
-										"type": "mirror",
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -371,22 +361,21 @@ func TestHelperGroupBlockDeviceNamesByHostName(t *testing.T) {
 												"blockDeviceName": "bd24",
 											},
 										},
-										"type": "mirror",
 									},
 								},
 							},
 							// pool on node-003
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-003",
 								},
-								// 1 raidGroups per pool
-								"raidGroups": []interface{}{
+								// 1 dataRaidGroups per pool
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -396,7 +385,6 @@ func TestHelperGroupBlockDeviceNamesByHostName(t *testing.T) {
 												"blockDeviceName": "bd32",
 											},
 										},
-										"type": "mirror",
 									},
 								},
 							},
@@ -406,9 +394,9 @@ func TestHelperGroupBlockDeviceNamesByHostName(t *testing.T) {
 			},
 			isErr: false,
 			expect: map[string][]string{
-				"node-001": []string{"bd11", "bd12", "bd13", "bd14", "bd15", "bd16"},
-				"node-002": []string{"bd21", "bd22", "bd23", "bd24"},
-				"node-003": []string{"bd31", "bd32"},
+				"node-001": {"bd11", "bd12", "bd13", "bd14", "bd15", "bd16"},
+				"node-002": {"bd21", "bd22", "bd23", "bd24"},
+				"node-003": {"bd31", "bd32"},
 			},
 		},
 	}
@@ -448,21 +436,21 @@ func TestHelperGroupBlockDeviceNamesByHostNameOrCached(t *testing.T) {
 	}{
 		"cspc - 1 cached host": {
 			cached: map[string][]string{
-				"node-001": []string{"bd1"},
+				"node-001": {"bd1"},
 			},
 			expect: map[string][]string{
-				"node-001": []string{"bd1"},
+				"node-001": {"bd1"},
 			},
 			isErr: false,
 		},
 		"cspc - 2 cached hosts": {
 			cached: map[string][]string{
-				"node-001": []string{"bd1"},
-				"node-002": []string{"bd2"},
+				"node-001": {"bd1"},
+				"node-002": {"bd2"},
 			},
 			expect: map[string][]string{
-				"node-001": []string{"bd1"},
-				"node-002": []string{"bd2"},
+				"node-001": {"bd1"},
+				"node-002": {"bd2"},
 			},
 			isErr: false,
 		},

--- a/config/localdevice/metac.yaml
+++ b/config/localdevice/metac.yaml
@@ -79,7 +79,7 @@ spec:
   attachments:
     - apiVersion: openebs.io/v1alpha1
       resource: blockdevices
-    - apiVersion: openebs.io/v1alpha1
+    - apiVersion: cstor.openebs.io/v1
       resource: cstorpoolclusters
       updateStrategy:
         method: InPlace
@@ -112,7 +112,7 @@ spec:
       matchLabels:
         cspc.openebs.io/version: v1
   attachments:
-    - apiVersion: openebs.io/v1alpha1
+    - apiVersion: cstor.openebs.io/v1
       resource: cstorpoolclusters
       advancedSelector:
         selectorTerms:

--- a/controller/localdevice/finalizer_test.go
+++ b/controller/localdevice/finalizer_test.go
@@ -471,7 +471,7 @@ func TestFinalize(t *testing.T) {
 				},
 				Attachments: common.MakeAnyUnstructRegistry(
 					[]*unstructured.Unstructured{
-						&unstructured.Unstructured{
+						{
 							Object: map[string]interface{}{
 								"kind":       "CStorPoolCluster",
 								"apiVersion": "openebs.io/v1alpha1",

--- a/controller/localdevice/reconciler_test.go
+++ b/controller/localdevice/reconciler_test.go
@@ -1715,10 +1715,6 @@ func TestReconcilerBuildDesiredCStorPoolCluster(t *testing.T) {
 											map[string]interface{}{
 												"blockDeviceName": "bd10",
 											},
-										},
-									},
-									map[string]interface{}{
-										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd11",
 											},
@@ -1741,10 +1737,6 @@ func TestReconcilerBuildDesiredCStorPoolCluster(t *testing.T) {
 											map[string]interface{}{
 												"blockDeviceName": "bd20",
 											},
-										},
-									},
-									map[string]interface{}{
-										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd21",
 											},

--- a/controller/localdevice/reconciler_test.go
+++ b/controller/localdevice/reconciler_test.go
@@ -329,8 +329,8 @@ func TestSyncerSkipIfEmptyAttachments(t *testing.T) {
 				request: &generic.SyncHookRequest{
 					Attachments: common.AnyUnstructRegistry(
 						map[string]map[string]*unstructured.Unstructured{
-							"gvk1": map[string]*unstructured.Unstructured{},
-							"gvk2": map[string]*unstructured.Unstructured{
+							"gvk1": {},
+							"gvk2": {
 								"nsname1": nil,
 							},
 						},
@@ -345,11 +345,11 @@ func TestSyncerSkipIfEmptyAttachments(t *testing.T) {
 				request: &generic.SyncHookRequest{
 					Attachments: common.AnyUnstructRegistry(
 						map[string]map[string]*unstructured.Unstructured{
-							"gvk1": map[string]*unstructured.Unstructured{},
-							"gvk2": map[string]*unstructured.Unstructured{
+							"gvk1": {},
+							"gvk2": {
 								"nsname1": nil,
 							},
-							"gvk3": map[string]*unstructured.Unstructured{
+							"gvk3": {
 								"nsname1": &unstructured.Unstructured{
 									Object: map[string]interface{}{},
 								},
@@ -407,7 +407,7 @@ func TestSyncerRegisterAttachments(t *testing.T) {
 				request: &generic.SyncHookRequest{
 					Attachments: common.AnyUnstructRegistry(
 						map[string]map[string]*unstructured.Unstructured{
-							"gvk1": map[string]*unstructured.Unstructured{
+							"gvk1": {
 								"nsname1": &unstructured.Unstructured{
 									Object: map[string]interface{}{
 										"kind": string(types.KindBlockDevice),
@@ -427,7 +427,7 @@ func TestSyncerRegisterAttachments(t *testing.T) {
 				request: &generic.SyncHookRequest{
 					Attachments: common.AnyUnstructRegistry(
 						map[string]map[string]*unstructured.Unstructured{
-							"gvk1": map[string]*unstructured.Unstructured{
+							"gvk1": {
 								"nsname1": &unstructured.Unstructured{
 									Object: map[string]interface{}{
 										"kind": string(types.KindBlockDevice),
@@ -467,7 +467,7 @@ func TestSyncerRegisterAttachments(t *testing.T) {
 					},
 					Attachments: common.AnyUnstructRegistry(
 						map[string]map[string]*unstructured.Unstructured{
-							"gvk1": map[string]*unstructured.Unstructured{
+							"gvk1": {
 								"nsname1": &unstructured.Unstructured{
 									Object: map[string]interface{}{
 										"kind": string(types.KindBlockDevice),
@@ -479,7 +479,7 @@ func TestSyncerRegisterAttachments(t *testing.T) {
 									},
 								},
 							},
-							"gvk2": map[string]*unstructured.Unstructured{
+							"gvk2": {
 								"nsname1": &unstructured.Unstructured{
 									Object: map[string]interface{}{
 										"kind": string(types.KindCStorPoolCluster),
@@ -512,7 +512,7 @@ func TestSyncerRegisterAttachments(t *testing.T) {
 					},
 					Attachments: common.AnyUnstructRegistry(
 						map[string]map[string]*unstructured.Unstructured{
-							"gvk1": map[string]*unstructured.Unstructured{
+							"gvk1": {
 								"nsname1": &unstructured.Unstructured{
 									Object: map[string]interface{}{
 										"kind": string(types.KindBlockDevice),
@@ -524,7 +524,7 @@ func TestSyncerRegisterAttachments(t *testing.T) {
 									},
 								},
 							},
-							"gvk2": map[string]*unstructured.Unstructured{
+							"gvk2": {
 								"nsname1": &unstructured.Unstructured{
 									Object: map[string]interface{}{
 										"kind": string(types.KindCStorPoolCluster),
@@ -609,7 +609,7 @@ func TestSyncerReconcile(t *testing.T) {
 					},
 				},
 				blockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{},
+					{},
 				},
 			},
 			isErr: true,
@@ -647,7 +647,7 @@ func TestSyncerReconcile(t *testing.T) {
 					},
 				},
 				blockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -690,7 +690,7 @@ func TestSyncerReconcile(t *testing.T) {
 					},
 				},
 				blockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -739,7 +739,7 @@ func TestSyncerReconcile(t *testing.T) {
 					},
 				},
 				blockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -751,7 +751,7 @@ func TestSyncerReconcile(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -807,7 +807,7 @@ func TestSyncerReconcile(t *testing.T) {
 					},
 				},
 				blockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -819,7 +819,7 @@ func TestSyncerReconcile(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -831,7 +831,7 @@ func TestSyncerReconcile(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -843,7 +843,7 @@ func TestSyncerReconcile(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -899,7 +899,7 @@ func TestSyncerReconcile(t *testing.T) {
 					},
 				},
 				blockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -911,7 +911,7 @@ func TestSyncerReconcile(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -923,7 +923,7 @@ func TestSyncerReconcile(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -935,7 +935,7 @@ func TestSyncerReconcile(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -947,7 +947,7 @@ func TestSyncerReconcile(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -959,7 +959,7 @@ func TestSyncerReconcile(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -1024,7 +1024,7 @@ func TestReconcilerIsObservedBlockDeviceCountMatchRAIDType(t *testing.T) {
 			reconciler: &Reconciler{
 				ObservedCStorClusterConfig: nil,
 				hostNameToSelectedBlockDeviceNames: map[string][]string{
-					"node-001": []string{"bd1"},
+					"node-001": {"bd1"},
 				},
 			},
 			isErr: true,
@@ -1042,7 +1042,7 @@ func TestReconcilerIsObservedBlockDeviceCountMatchRAIDType(t *testing.T) {
 					},
 				},
 				hostNameToSelectedBlockDeviceNames: map[string][]string{
-					"node-001": []string{"bd1"},
+					"node-001": {"bd1"},
 				},
 			},
 			isErr: true,
@@ -1060,7 +1060,7 @@ func TestReconcilerIsObservedBlockDeviceCountMatchRAIDType(t *testing.T) {
 					},
 				},
 				hostNameToSelectedBlockDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2"},
+					"node-001": {"bd1", "bd2"},
 				},
 			},
 			isErr: false,
@@ -1078,8 +1078,8 @@ func TestReconcilerIsObservedBlockDeviceCountMatchRAIDType(t *testing.T) {
 					},
 				},
 				hostNameToSelectedBlockDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2"},
-					"node-002": []string{"bd21", "bd22", "bd23"},
+					"node-001": {"bd1", "bd2"},
+					"node-002": {"bd21", "bd22", "bd23"},
 				},
 			},
 			isErr: true,
@@ -1097,7 +1097,7 @@ func TestReconcilerIsObservedBlockDeviceCountMatchRAIDType(t *testing.T) {
 					},
 				},
 				hostNameToSelectedBlockDeviceNames: map[string][]string{
-					"node-001": []string{"bd1"},
+					"node-001": {"bd1"},
 				},
 			},
 			isErr: false,
@@ -1115,8 +1115,8 @@ func TestReconcilerIsObservedBlockDeviceCountMatchRAIDType(t *testing.T) {
 					},
 				},
 				hostNameToSelectedBlockDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2"},
-					"node-002": []string{"bd21"},
+					"node-001": {"bd1", "bd2"},
+					"node-002": {"bd21"},
 				},
 			},
 			isErr: false,
@@ -1134,8 +1134,8 @@ func TestReconcilerIsObservedBlockDeviceCountMatchRAIDType(t *testing.T) {
 					},
 				},
 				hostNameToSelectedBlockDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2", "bd3"},
-					"node-002": []string{"bd21", "bd22", "bd23"},
+					"node-001": {"bd1", "bd2", "bd3"},
+					"node-002": {"bd21", "bd22", "bd23"},
 				},
 			},
 			isErr: false,
@@ -1153,8 +1153,8 @@ func TestReconcilerIsObservedBlockDeviceCountMatchRAIDType(t *testing.T) {
 					},
 				},
 				hostNameToSelectedBlockDeviceNames: map[string][]string{
-					"node-001": []string{"bd1", "bd2", "bd3"},
-					"node-002": []string{"bd21", "bd22"},
+					"node-001": {"bd1", "bd2", "bd3"},
+					"node-002": {"bd21", "bd22"},
 				},
 			},
 			isErr: true,
@@ -1199,7 +1199,7 @@ func TestReconcilerMapHostNameToSelectedBlockDevices(t *testing.T) {
 		"1 invalid kind observed device": {
 			reconciler: &Reconciler{
 				selectedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": "Junk",
 						},
@@ -1211,7 +1211,7 @@ func TestReconcilerMapHostNameToSelectedBlockDevices(t *testing.T) {
 		"1 valid kind observed device && empty hostname": {
 			reconciler: &Reconciler{
 				selectedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 						},
@@ -1223,7 +1223,7 @@ func TestReconcilerMapHostNameToSelectedBlockDevices(t *testing.T) {
 		"1 valid kind observed device && valid hostname": {
 			reconciler: &Reconciler{
 				selectedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -1246,7 +1246,7 @@ func TestReconcilerMapHostNameToSelectedBlockDevices(t *testing.T) {
 		"2 valid kind observed devices && valid, invalid hostname": {
 			reconciler: &Reconciler{
 				selectedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -1258,7 +1258,7 @@ func TestReconcilerMapHostNameToSelectedBlockDevices(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -1275,7 +1275,7 @@ func TestReconcilerMapHostNameToSelectedBlockDevices(t *testing.T) {
 		"2 valid kind observed devices && valid single hostname": {
 			reconciler: &Reconciler{
 				selectedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -1287,7 +1287,7 @@ func TestReconcilerMapHostNameToSelectedBlockDevices(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -1310,7 +1310,7 @@ func TestReconcilerMapHostNameToSelectedBlockDevices(t *testing.T) {
 		"2 valid kind observed devices && valid hostnames": {
 			reconciler: &Reconciler{
 				selectedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -1322,7 +1322,7 @@ func TestReconcilerMapHostNameToSelectedBlockDevices(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -1448,24 +1448,20 @@ func TestReconcilerWalkObservedCStorPoolCluster(t *testing.T) {
 							"pools": []interface{}{
 								map[string]interface{}{
 									"poolConfig": map[string]interface{}{
-										"defaultRaidGroupType": "stripe",
-										"overProvisioning":     false,
-										"compression":          "off",
+										"dataRaidGroupType": "stripe",
+										"thickProvision":    false,
+										"compression":       "off",
 									},
 									"nodeSelector": map[string]interface{}{
 										"kubernetes.io/hostname": "node-201",
 									},
-									"raidGroups": []interface{}{
+									"dataRaidGroups": []interface{}{
 										map[string]interface{}{
 											"blockDevices": []interface{}{
 												map[string]interface{}{
 													"blockDeviceName": "bd-7",
 												},
 											},
-											"type":         "stripe",
-											"isWriteCache": false,
-											"isSpare":      false,
-											"isReadCache":  false,
 										},
 									},
 								},
@@ -1476,7 +1472,7 @@ func TestReconcilerWalkObservedCStorPoolCluster(t *testing.T) {
 			},
 			expectHostNames: []string{"node-201"},
 			expectHostToDeviceNames: map[string][]string{
-				"node-201": []string{"bd-7"},
+				"node-201": {"bd-7"},
 			},
 			isErr: false,
 		},
@@ -1489,37 +1485,33 @@ func TestReconcilerWalkObservedCStorPoolCluster(t *testing.T) {
 							"pools": []interface{}{
 								map[string]interface{}{
 									"poolConfig": map[string]interface{}{
-										"defaultRaidGroupType": "stripe",
-										"overProvisioning":     false,
-										"compression":          "off",
+										"dataRaidGroupType": "stripe",
+										"thickProvision":    false,
+										"compression":       "off",
 									},
 									"nodeSelector": map[string]interface{}{
 										"kubernetes.io/hostname": "node-101",
 									},
-									"raidGroups": []interface{}{
+									"dataRaidGroups": []interface{}{
 										map[string]interface{}{
 											"blockDevices": []interface{}{
 												map[string]interface{}{
 													"blockDeviceName": "bd-8",
 												},
 											},
-											"type":         "stripe",
-											"isWriteCache": false,
-											"isSpare":      false,
-											"isReadCache":  false,
 										},
 									},
 								},
 								map[string]interface{}{
 									"poolConfig": map[string]interface{}{
-										"defaultRaidGroupType": "stripe",
-										"overProvisioning":     false,
-										"compression":          "off",
+										"dataRaidGroupType": "stripe",
+										"thickProvision":    false,
+										"compression":       "off",
 									},
 									"nodeSelector": map[string]interface{}{
 										"kubernetes.io/hostname": "node-201",
 									},
-									"raidGroups": []interface{}{
+									"dataRaidGroups": []interface{}{
 										map[string]interface{}{
 											"blockDevices": []interface{}{
 												map[string]interface{}{
@@ -1529,10 +1521,6 @@ func TestReconcilerWalkObservedCStorPoolCluster(t *testing.T) {
 													"blockDeviceName": "bd-77",
 												},
 											},
-											"type":         "stripe",
-											"isWriteCache": false,
-											"isSpare":      false,
-											"isReadCache":  false,
 										},
 									},
 								},
@@ -1543,8 +1531,8 @@ func TestReconcilerWalkObservedCStorPoolCluster(t *testing.T) {
 			},
 			expectHostNames: []string{"node-101", "node-201"},
 			expectHostToDeviceNames: map[string][]string{
-				"node-101": []string{"bd-8"},
-				"node-201": []string{"bd-7", "bd-77"},
+				"node-101": {"bd-8"},
+				"node-201": {"bd-7", "bd-77"},
 			},
 			isErr: false,
 		},
@@ -1604,19 +1592,19 @@ func TestReconcilerBuildDesiredCStorPoolCluster(t *testing.T) {
 				},
 				observedHostNamesInCSPC: []string{"node-001", "node-002"},
 				hostNameToObservedCSPCDeviceNames: map[string][]string{
-					"node-001": []string{"bd10"},
-					"node-002": []string{"bd20"},
+					"node-001": {"bd10"},
+					"node-002": {"bd20"},
 				},
 				hostNameToSelectedBlockDeviceNames: map[string][]string{
-					"node-001": []string{"bd10", "bd11"},
-					"node-002": []string{"bd20", "bd21"},
+					"node-001": {"bd10", "bd11"},
+					"node-002": {"bd20", "bd21"},
 				},
 				raidType: types.PoolRAIDTypeMirror,
 			},
 			expectCSPC: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": types.APIVersionOpenEBSV1Alpha1,
+					"apiVersion": types.APIVersionCStorOpenEBSV1,
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -1629,14 +1617,14 @@ func TestReconcilerBuildDesiredCStorPoolCluster(t *testing.T) {
 						"pools": []interface{}{
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -1646,23 +1634,19 @@ func TestReconcilerBuildDesiredCStorPoolCluster(t *testing.T) {
 												"blockDeviceName": "bd11",
 											},
 										},
-										"type":         "mirror",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-002",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -1672,10 +1656,6 @@ func TestReconcilerBuildDesiredCStorPoolCluster(t *testing.T) {
 												"blockDeviceName": "bd21",
 											},
 										},
-										"type":         "mirror",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
@@ -1697,19 +1677,19 @@ func TestReconcilerBuildDesiredCStorPoolCluster(t *testing.T) {
 				},
 				observedHostNamesInCSPC: []string{"node-001", "node-002"},
 				hostNameToObservedCSPCDeviceNames: map[string][]string{
-					"node-001": []string{"bd10"},
-					"node-002": []string{"bd20"},
+					"node-001": {"bd10"},
+					"node-002": {"bd20"},
 				},
 				hostNameToSelectedBlockDeviceNames: map[string][]string{
-					"node-001": []string{"bd10", "bd11"},
-					"node-002": []string{"bd20", "bd21"},
+					"node-001": {"bd10", "bd11"},
+					"node-002": {"bd20", "bd21"},
 				},
 				raidType: types.PoolRAIDTypeStripe,
 			},
 			expectCSPC: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": types.APIVersionOpenEBSV1Alpha1,
+					"apiVersion": types.APIVersionCStorOpenEBSV1,
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -1722,24 +1702,20 @@ func TestReconcilerBuildDesiredCStorPoolCluster(t *testing.T) {
 						"pools": []interface{}{
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "stripe",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "stripe",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd10",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -1747,33 +1723,25 @@ func TestReconcilerBuildDesiredCStorPoolCluster(t *testing.T) {
 												"blockDeviceName": "bd11",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "stripe",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "stripe",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-002",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
 												"blockDeviceName": "bd20",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 									map[string]interface{}{
 										"blockDevices": []interface{}{
@@ -1781,10 +1749,6 @@ func TestReconcilerBuildDesiredCStorPoolCluster(t *testing.T) {
 												"blockDeviceName": "bd21",
 											},
 										},
-										"type":         "stripe",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
@@ -1834,7 +1798,7 @@ func TestReconcilerReconcile(t *testing.T) {
 		"nil ObservedCStorClusterConfig": {
 			reconciler: &Reconciler{
 				ObservedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{},
 					},
 				},
@@ -1845,7 +1809,7 @@ func TestReconcilerReconcile(t *testing.T) {
 		"invalid ObservedCStorClusterConfig": {
 			reconciler: &Reconciler{
 				ObservedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{},
 					},
 				},
@@ -1860,7 +1824,7 @@ func TestReconcilerReconcile(t *testing.T) {
 		"expect mirror cspc when observed cspc is nil": {
 			reconciler: &Reconciler{
 				ObservedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -1871,7 +1835,7 @@ func TestReconcilerReconcile(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -1915,7 +1879,7 @@ func TestReconcilerReconcile(t *testing.T) {
 			expectCSPC: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       string(types.KindCStorPoolCluster),
-					"apiVersion": types.APIVersionOpenEBSV1Alpha1,
+					"apiVersion": types.APIVersionCStorOpenEBSV1,
 					"metadata": map[string]interface{}{
 						"name":      "test",
 						"namespace": "test",
@@ -1928,14 +1892,14 @@ func TestReconcilerReconcile(t *testing.T) {
 						"pools": []interface{}{
 							map[string]interface{}{
 								"poolConfig": map[string]interface{}{
-									"defaultRaidGroupType": "mirror",
-									"overProvisioning":     false,
-									"compression":          "off",
+									"dataRaidGroupType": "mirror",
+									"thickProvision":    false,
+									"compression":       "off",
 								},
 								"nodeSelector": map[string]interface{}{
 									"kubernetes.io/hostname": "node-001",
 								},
-								"raidGroups": []interface{}{
+								"dataRaidGroups": []interface{}{
 									map[string]interface{}{
 										"blockDevices": []interface{}{
 											map[string]interface{}{
@@ -1945,10 +1909,6 @@ func TestReconcilerReconcile(t *testing.T) {
 												"blockDeviceName": "bd2",
 											},
 										},
-										"type":         "mirror",
-										"isWriteCache": false,
-										"isSpare":      false,
-										"isReadCache":  false,
 									},
 								},
 							},
@@ -2002,7 +1962,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 		"no blockdevice selector": {
 			reconciler: &Reconciler{
 				ObservedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -2021,7 +1981,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 		"select all blockdevices": {
 			reconciler: &Reconciler{
 				ObservedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -2033,7 +1993,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -2077,7 +2037,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 				},
 			},
 			expectBlockDevices: []*unstructured.Unstructured{
-				&unstructured.Unstructured{
+				{
 					Object: map[string]interface{}{
 						"kind": string(types.KindBlockDevice),
 						"metadata": map[string]interface{}{
@@ -2089,7 +2049,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 						},
 					},
 				},
-				&unstructured.Unstructured{
+				{
 					Object: map[string]interface{}{
 						"kind": string(types.KindBlockDevice),
 						"metadata": map[string]interface{}{
@@ -2107,7 +2067,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 		"passing path based blockdevice selector term": {
 			reconciler: &Reconciler{
 				ObservedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -2119,7 +2079,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -2158,7 +2118,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 				},
 			},
 			expectBlockDevices: []*unstructured.Unstructured{
-				&unstructured.Unstructured{
+				{
 					Object: map[string]interface{}{
 						"kind": string(types.KindBlockDevice),
 						"metadata": map[string]interface{}{
@@ -2176,7 +2136,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 		"failing path based blockdevice selector term": {
 			reconciler: &Reconciler{
 				ObservedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -2188,7 +2148,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -2231,7 +2191,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 		"passing label based blockdevice selector term": {
 			reconciler: &Reconciler{
 				ObservedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -2246,7 +2206,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -2288,7 +2248,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 				},
 			},
 			expectBlockDevices: []*unstructured.Unstructured{
-				&unstructured.Unstructured{
+				{
 					Object: map[string]interface{}{
 						"kind": string(types.KindBlockDevice),
 						"metadata": map[string]interface{}{
@@ -2309,7 +2269,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 		"failing label based blockdevice selector term": {
 			reconciler: &Reconciler{
 				ObservedBlockDevices: []*unstructured.Unstructured{
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{
@@ -2324,7 +2284,7 @@ func TestReconcilerSelectFromObservedBlockDevices(t *testing.T) {
 							},
 						},
 					},
-					&unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"kind": string(types.KindBlockDevice),
 							"metadata": map[string]interface{}{

--- a/types/gvk.go
+++ b/types/gvk.go
@@ -25,9 +25,17 @@ const (
 	// custom resources defined in openebs
 	GroupOpenEBSIO string = "openebs.io"
 
+	// GroupCStorOpenEBSIO refers to the group for all
+	// custom resources defined for cStor
+	GroupCStorOpenEBSIO string = "cstor.openebs.io"
+
 	// VersionV1Alpha1 refers to v1alpha1 version of the
 	// custom resources used here
 	VersionV1Alpha1 string = "v1alpha1"
+
+	// VersionV1 refers to v1version of the custom resources
+	// used here
+	VersionV1 string = "v1"
 
 	// APIVersionDAOMayaDataV1Alpha1 refers to v1alpha1 api
 	// version of DAO based custom resources
@@ -36,6 +44,10 @@ const (
 	// APIVersionOpenEBSV1Alpha1 refers to v1alpha1 api
 	// version of openebs based custom resources
 	APIVersionOpenEBSV1Alpha1 string = GroupOpenEBSIO + "/" + VersionV1Alpha1
+
+	// APIVersionCStorOpenEBSV1 refers to v1 api version of cStor
+	// based custom resources present in OpenEBS project
+	APIVersionCStorOpenEBSV1 string = GroupCStorOpenEBSIO + "/" + VersionV1
 )
 
 // Kind is a custom datatype to refer to kubernetes native


### PR DESCRIPTION
This commit has following changes:
- `poolConfig.defaultRaidGroupType` renamed to `poolConfig.dataRaidGroupType` 
- `poolConfig.overProvisioning` renamed to `poolConfig.thickProvision`

```yaml
poolConfig:
  compression: off
  dataRaidGroupType: stripe
  thickProvision: false
```

- `v1` API splits `raidGroups` of `v1alpha1` to `dataRaidGroups` & `writeCacheGroups`
```yaml
spec:
  pools:
  - nodeSelector:
      kubernetes.io/hostname: noded-1
    dataRaidGroups:
    -  blockDevices:
      - blockDeviceName: blockdevice-1-node-1
```
- Stripe is now built as a single raid group of n devices instead of earlier strategy to build n groups each having 1 disk.